### PR TITLE
Fix Fiends never going into their pain animation

### DIFF
--- a/demon.qc
+++ b/demon.qc
@@ -135,7 +135,7 @@ void(entity attacker, float damage)	demon1_pain =
 
 	self.pain_finished = time + 1;
     sound (self, CHAN_VOICE, "demon/dpain1.wav", 1, ATTN_NORM);
-    return;		// allready dying, don't go into pain frame
+
 	if (random()*200 > damage)
 		return;		// didn't flinch
 


### PR DESCRIPTION
There was a stray "return" statement in demon1_pain() which meant that
the function would always return without causing the monster to go into
its pain animation.  It looks like the "return" statement was added by
accident.  This commit removes it.

Fixing this also eliminates a compiler warning (FTEQCC previously issued
a warning about the fact that the code after the "return" statement was
unreachable).