### PR TITLE
Fix a critical bug involving func_elvtr_button

### DIFF
--- a/doeplats.qc
+++ b/doeplats.qc
@@ -11,7 +11,7 @@ float START_AT_TOP  = 8;
 float PLAT2			= 16;
 float PLAT2_BOTTOM  = 32;
 
-float ELV_BUTN_DIR	= 0;
+float elv_butn_dir;
 
 // ==================================
 // down N and wait code
@@ -169,7 +169,7 @@ void() elvtr_use =
 	
 	self.elevatorLastUse = time;
 	
-	if (ELV_BUTN_DIR == 0)
+	if (elv_butn_dir == 0)
 		return;
 
 	elvPos = (self.absmin_z + self.absmax_z) * 0.5;
@@ -196,7 +196,7 @@ void() elvtr_use =
 		}
 	}
 		
-	if (ELV_BUTN_DIR == -1)
+	if (elv_butn_dir == -1)
 	{	
 		if(self.elevatorOnFloor > 0)
 		{
@@ -204,7 +204,7 @@ void() elvtr_use =
 			elvtr_go ();
 		}
 	}
-	else if(ELV_BUTN_DIR == 1)
+	else if(elv_butn_dir == 1)
 	{
 		if(self.elevatorOnFloor < (self.cnt - 1))
 		{

--- a/elevatr.qc
+++ b/elevatr.qc
@@ -9,11 +9,11 @@ void() elvtr_button_return;
 
 void() elvtr_button_wait =
 {
-	ELV_BUTN_DIR = 0;
+	elv_butn_dir = 0;
 	if (self.spawnflags & ELVTR_DOWN)
-		ELV_BUTN_DIR = -1;
+		elv_butn_dir = -1;
 	else
-		ELV_BUTN_DIR = 1;
+		elv_butn_dir = 1;
 		
 	self.state = STATE_TOP;
 	self.nextthink = self.ltime + self.wait;


### PR DESCRIPTION
This commit fixes a nasty bug which progs_dump inherited along with the
code for func_elvtr_button, which originated in the Rogue mission pack
(Dissolution of Eternity).

The problem was that the function elvtr_button_wait() made assignments
to the global constant ELV_BUTN_DIR.  What's really insidious about this
bug is that the results of assigning to a constant are
compiler-dependent.  It seems that when the mission pack code was
compiled with the original QCC compiler, back in the day, this didn't
cause a problem.  However, if this code is compiled with a modern
compiler, like FTEQCC, it's liable to cause a critical error during
gameplay.  I expect this is because of how modern compilers optimize the
storage of constants.

The error that occurs during gameplay will likely differ from compiler
to compiler, but my experience (compiling with FTEQCC) is that the game
goes into meltdown after the player touches a func_elvtr_button: the
player's weapon model gets frozen on a certain frame, and firing the
weapon will cause the game to quit with an unrelated error message.
However, because this is a storage-related issue, you might get
different results depending on other specifics.

This commit eliminates the assignment-to-constant problem by making
ELV_BUTN_DIR a global variable instead of a global constant.  I've also
renamed it to "elv_butn_dir" to fit the usual naming convention (lower
case for variables, upper case for constants).

When it was a global constant, it was explicitly initialized to zero.
Now that it's a global variable, the engine will automatically
initialize it to zero, so there shouldn't be any change in behavior.

Fixing this also eliminates a number of warning messages that FTEQCC
issued in relation to the assignment-to-constant.