### PR TITLE
Address various FTEQCC warnings

### DIFF
--- a/ai.qc
+++ b/ai.qc
@@ -297,8 +297,6 @@ local float	rsnd;
 		sound (self, CHAN_VOICE, "hknight/sight1.wav", 1, ATTN_NORM);
 	else if (self.classname == "monster_tarbaby")
 		sound (self, CHAN_VOICE, "blob/sight1.wav", 1, ATTN_NORM);
-	else if (self.classname == "monster_vomit")
-		sound (self, CHAN_VOICE, "vomitus/v_sight1.wav", 1, ATTN_NORM);
 	else if (self.classname == "monster_enforcer")
 	{
 		rsnd = rint(random() * 3);

--- a/client.qc
+++ b/client.qc
@@ -2,7 +2,7 @@
 // prototypes
 void () W_WeaponFrame;
 void() W_SetCurrentAmmo;
-void() player_pain;
+void(entity attacker, float damage) player_pain;
 void() player_stand1;
 //void (vector org) spawn_tfog; //moved to items.qc -- dumptruck_ds
 void (vector org, entity death_owner) spawn_tdeath;

--- a/defs.qc
+++ b/defs.qc
@@ -736,7 +736,7 @@ float STAT_TOTALMONSTERS = 12;
 .float		reset_items; //dumptruck_ds
 .float		spawn_angry; //dumptruck_ds
 .string		mdl_debris; //dumptruck_ds
-.float		keep_ammo //dumptruck_ds
+.float		keep_ammo; //dumptruck_ds
 
 /*============================================================================
 johnfitz new defs from Rubicon2
@@ -779,6 +779,6 @@ void() SUB_UsePain; //dumptruck_ds
 .float megahealth_rottime; // dumptruck_ds
 .float alpha; // from RennyC func_drop in dtmisc.qc
 .float		ltrailLastUsed;  //from DOE lighnin
-.float style2 //c0burn's switchable lights
-.float sight_trigger //dumptruck_ds
-.float keep_ammo //dumptruck_ds
+.float style2; //c0burn's switchable lights
+.float sight_trigger; //dumptruck_ds
+.float keep_ammo; //dumptruck_ds

--- a/dog.qc
+++ b/dog.qc
@@ -195,7 +195,7 @@ void() dog_painb14	=[	$painb14 ,	dog_painb15	] {};
 void() dog_painb15	=[	$painb15 ,	dog_painb16	] {};
 void() dog_painb16	=[	$painb16 ,	dog_run1	] {};
 
-void() dog_pain =
+void(entity attacker, float damage) dog_pain =
 {
 
   if (self.health <= self.pain_threshold) //dumptruck_ds

--- a/doors.qc
+++ b/doors.qc
@@ -578,7 +578,7 @@ void () fd_secret_use =
 
 	if (!(self.spawnflags & SECRET_NO_SHOOT))
 	{
-		self.th_pain = SUB_Null;
+		self.th_pain = SUB_NullPain;
 		self.takedamage = DAMAGE_NO;
 	}
 	self.velocity = '0 0 0';
@@ -611,6 +611,8 @@ void () fd_secret_use =
 	SUB_CalcMove(self.dest1, self.speed, fd_secret_move1);
 	sound(self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
 };
+
+void(entity attacker, float damage) fd_secret_pain = { fd_secret_use(); };
 
 // Wait after first movement...
 void () fd_secret_move1 =
@@ -665,7 +667,7 @@ void () fd_secret_done =
 	{
 		self.health = 10000;
 		self.takedamage = DAMAGE_YES;
-		self.th_pain = fd_secret_use;
+		self.th_pain = fd_secret_pain;
 	}
 	sound(self, CHAN_VOICE, self.noise3, 1, ATTN_NORM);
 };
@@ -769,7 +771,7 @@ void () func_door_secret =
 	{
 		self.health = 10000;
 		self.takedamage = DAMAGE_YES;
-		self.th_pain = fd_secret_use;
+		self.th_pain = fd_secret_pain;
 		self.th_die = fd_secret_use;
 	}
 	self.oldorigin = self.origin;

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -546,7 +546,7 @@ void() func_fall_think =
         // self.solid = SOLID_NOT;
         self.movetype = MOVETYPE_TOSS;
 
-        if (!self.spawnflags & DONT_FADE)
+        if (!(self.spawnflags & DONT_FADE))
         {
 
           if (self.alpha > 0.1)
@@ -565,7 +565,7 @@ void() fall_touch =
 {
     if (other.classname == "player")
     {
-        if (!other.flags & FL_ONGROUND)
+        if (!(other.flags & FL_ONGROUND))
             other.flags = other.flags | FL_ONGROUND;
     }
 

--- a/elevatr.qc
+++ b/elevatr.qc
@@ -100,8 +100,6 @@ When a button is touched, it moves some distance in the direction of it's angle,
 */
 void() func_elvtr_button =
 {
-local float		gtemp, ftemp;
-
 	if (self.sounds == 0)
 	{
 		precache_sound ("buttons/airbut1.wav");

--- a/hipcount.qc
+++ b/hipcount.qc
@@ -98,8 +98,6 @@ void() counter_off_use =
 
 float( entity counter ) counter_GetCount =
 	{
-	local float value;
-
 	if ( counter.classname == "counter" )
 		{
 		return counter.state;

--- a/items.qc
+++ b/items.qc
@@ -655,7 +655,7 @@ void() weapon_shotgun =
 		if (!self.spawnflags)
 		{
 			self.spawnflags = 2;
-		};
+		}
 
 		if (self.spawnflags & 2)
 		{

--- a/misc.qc
+++ b/misc.qc
@@ -390,14 +390,14 @@ void() spikeshooter_use =
 
 	if (self.spawnflags & SPAWNFLAG_LASER)
 	{
-      if (!self.spawnflags & SPAWNFLAG_SILENT)
+      if (!(self.spawnflags & SPAWNFLAG_SILENT))
 		  sound (self, CHAN_VOICE, "enforcer/enfire.wav", 1, ATTN_NORM);
 			LaunchLaser (self.origin, self.movedir);
       newmis.spawnflags = self.spawnflags;
 	}
    else if (self.spawnflags & SPAWNFLAG_LAVABALL)
    {
-      if (!self.spawnflags & SPAWNFLAG_SILENT)
+      if (!(self.spawnflags & SPAWNFLAG_SILENT))
       sound (self, CHAN_VOICE, "boss1/throw.wav", 1, ATTN_NORM); //dms
       // sound (self, CHAN_VOICE, "knight/sword2.wav", 1, ATTN_NORM); //dms
       // sound (self, CHAN_VOICE, "weapons/ax1.wav", 1, ATTN_NORM); //dms
@@ -420,7 +420,7 @@ void() spikeshooter_use =
 
 	 else if (self.spawnflags & SPAWNFLAG_ROCKET)
 	 {
-		 if (!self.spawnflags & SPAWNFLAG_SILENT)
+		 if (!(self.spawnflags & SPAWNFLAG_SILENT))
 		 sound (self, CHAN_VOICE, "weapons/sgun1.wav", 1, ATTN_NORM);
 		 rockettrap = spawn();
 		 rockettrap.movetype = MOVETYPE_FLYMISSILE;
@@ -440,7 +440,7 @@ void() spikeshooter_use =
 	 }
 	 else if (self.spawnflags & SPAWNFLAG_VOREBALL)
 	 {
-		 if (!self.spawnflags & SPAWNFLAG_SILENT)
+		 if (!(self.spawnflags & SPAWNFLAG_SILENT))
 		 sound (self, CHAN_VOICE, "shalrath/attack2.wav", 1, ATTN_NORM);
 		 voreball = spawn();
 		 voreball.movetype = MOVETYPE_FLYMISSILE;
@@ -461,7 +461,7 @@ void() spikeshooter_use =
 
 	 else if (self.spawnflags & SPAWNFLAG_GRENADE)
 	 {
-		 if (!self.spawnflags & SPAWNFLAG_SILENT)
+		 if (!(self.spawnflags & SPAWNFLAG_SILENT))
 		 sound (self, CHAN_VOICE, "weapons/grenade.wav", 1, ATTN_NORM);
 		 gnade = spawn();
 		 gnade.movetype = MOVETYPE_BOUNCE;
@@ -484,7 +484,7 @@ void() spikeshooter_use =
 
 	else if (self.spawnflags & SPAWNFLAG_GIBS)
 	 {
-	 	if (!self.spawnflags & SPAWNFLAG_SILENT)
+	 	if (!(self.spawnflags & SPAWNFLAG_SILENT))
 		sound (self, CHAN_VOICE, "zombie/z_shot1.wav", 1, ATTN_NORM);
 	 	zgibs = spawn ();
 	 	zgibs.owner = self;
@@ -504,7 +504,7 @@ void() spikeshooter_use =
 
    else
 	{
-  if (!self.spawnflags & SPAWNFLAG_SILENT)
+  if (!(self.spawnflags & SPAWNFLAG_SILENT))
     sound (self, CHAN_VOICE, "weapons/spike2.wav", 1, ATTN_NORM);
 		launch_spike (self.origin, self.movedir);
 		newmis.velocity = self.movedir * 500;

--- a/monsters.qc
+++ b/monsters.qc
@@ -112,8 +112,6 @@ enemy as activator.
 */
 void() monster_death_use =
 {
-	local entity 	ent, otemp, stemp;
-
 // fall to ground
 	if (self.flags & FL_FLY)
 		self.flags = self.flags - FL_FLY;
@@ -148,9 +146,6 @@ void() monster_pain_use =
 
 void() walkmonster_start_go =
 {
-local string	stemp;
-local entity	etemp;
-
 	self.origin_z = self.origin_z + 1;	// raise off floor a bit
 //Preach's "check" here
 

--- a/oldone.qc
+++ b/oldone.qc
@@ -239,7 +239,7 @@ void() finale_4 =
 
 //============================================================================
 
-void () nopain =
+void(entity attacker, float damage) nopain =
 {
 	self.health = 40000;
 };

--- a/player.qc
+++ b/player.qc
@@ -334,7 +334,7 @@ void()	player_axpain4 =	[	$axpain4,	player_axpain5	] {};
 void()	player_axpain5 =	[	$axpain5,	player_axpain6	] {};
 void()	player_axpain6 =	[	$axpain6,	player_run	] {};
 
-void() player_pain =
+void(entity attacker, float damage) player_pain =
 {
 	if (self.weaponframe)
 		return;

--- a/rotate.qc
+++ b/rotate.qc
@@ -1067,7 +1067,6 @@ void() rotate_door_group_reversedirection =
 
 void() rotate_door_use =
    {
-   local entity t;
    local vector start;
 
    if ( ( self.state != STATE_OPEN ) && ( self.state != STATE_CLOSED ) )

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -21,7 +21,7 @@ $frame death1 death2 death3 death4 death5 death6 death7
 $frame	walk1 walk2 walk3 walk4 walk5 walk6 walk7 walk8 walk9 walk10
 $frame	walk11 walk12
 
-void() shalrath_pain;
+void(entity attacker, float damage) shalrath_pain;
 void() ShalMissile;
 void() shal_stand     =[      $walk1,       shal_stand    ] {ai_stand();};
 
@@ -87,7 +87,7 @@ void() shal_death6      =[      $death6,        shal_death7     ] {};
 void() shal_death7      =[      $death7,        shal_death7    ] {};
 
 
-void() shalrath_pain =
+void(entity attacker, float damage) shalrath_pain =
 {
 
   if (self.health <= self.pain_threshold) //dumptruck_ds

--- a/subs.qc
+++ b/subs.qc
@@ -2,6 +2,8 @@
 
 void() SUB_Null = {};
 
+void(entity attacker, float damage) SUB_NullPain = {};
+
 void() SUB_Remove = {remove(self);};
 
 

--- a/zombie.qc
+++ b/zombie.qc
@@ -194,7 +194,7 @@ ZombieFireGrenade
 */
 void(vector st) ZombieFireGrenade =
 {
-	local   entity missile, mpuff;
+	local   entity missile;
 	local   vector  org;
 
 	sound (self, CHAN_WEAPON, "zombie/z_shot1.wav", 1, ATTN_NORM);


### PR DESCRIPTION
This pull request addresses the remaining warnings issued by the current version of FTEQCC (at its default warning level) which aren't already addressed by one of the other pull requests I've sent.

There are multiple commits in this pull request.  Each commit addresses a different type of compiler warning.  Please see the full commit message for each commit for more explanation of each issue.

The things addressed in this pull request aren't things that should affect gameplay; they're things related to housekeeping and "best practice" (I use that term cautiously!).  I wanted to get the warning count down to zero before I moved on to other changes, so I can easily confirm that any other changes I make don't accidentally trigger any new warnings.