### PR TITLE
Make trigger_ladder ignore bad (up/down) angles

### DIFF
--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -396,6 +396,10 @@ Keys:
 */
 void() trigger_ladder =
 {
+	// ignore an "up" or "down" angle (doesn't make sense for a ladder)
+	if (self.angles_y == -1 || self.angles_y == -2)
+		self.angles_y = 0;
+
 	InitTrigger ();
 	self.touch = ladder_touch;
 };

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -398,7 +398,13 @@ void() trigger_ladder =
 {
 	// ignore an "up" or "down" angle (doesn't make sense for a ladder)
 	if (self.angles_y == -1 || self.angles_y == -2)
+	{
+		dprint ("WARNING: trigger_ladder ignored bad 'angle' value: ");
+		dprint (ftos (self.angles_y));
+		dprint ("\n");
+
 		self.angles_y = 0;
+	}
 
 	InitTrigger ();
 	self.touch = ladder_touch;


### PR DESCRIPTION
I noticed that the ladders in jamx_pinchy (a map I like immensely)
exhibited a curious bug: the player could only climb them if they held
the jump button while looking either directly forwards or more-or-less
upwards.  If the player looked even slightly downwards, they'd
immediately lose their grip on the ladder and fall like a brick.

It turned out that this happened because the map has the "angle" field
on each trigger_ladder set to -2.  trigger_ladder calls InitTrigger(),
which calls SetMovedir(), which interprets an angle of -1 or -2 to mean
"up" or "down".  An "up" or "down" angle makes sense for an entity like
func_door, but it doesn't make sense for trigger_ladder, because
ladder_touch() only lets the player hold onto the ladder if they're
looking in the corresponding direction.

It seems to me that it's better if the progs just doesn't allow a map to
set these bad angles on a trigger_ladder.  This commit makes it so that
an "up" or "down" angle on a trigger_ladder is ignored.  This makes the
ladders in jamx_pinchy behave normally.