### PR TITLE
Fix items not respawning in deathmatch mode

### DIFF
--- a/items.qc
+++ b/items.qc
@@ -309,14 +309,13 @@ void() health_touch =
 
 	self.model = string_null;
 	self.solid = SOLID_NOT;
-	// Megahealth = rot down the player's super health
 
 	if (!deathmatch)
-	CheckItemRespawn(self, 30);
+		CheckItemRespawn(self, 30);
 	self.think = SUB_regen;
 
+	// Megahealth = rot down the player's super health
 	if (self.healtype == 2)
-
 	{
 		other.megahealth_rottime = time + 5;  //thanks ydrol!!!
 		other.items = other.items | IT_SUPERHEALTH;
@@ -373,14 +372,10 @@ void() armor_touch =
 
 	self.solid = SOLID_NOT;
 	self.model = string_null;
-	// if (deathmatch == 1) Khreathor stuff
-	// 	self.nextthink = time + 20;
-	// self.think = SUB_regen;
 	// Supa, SP respawning items support
 	if (!deathmatch)
 		CheckItemRespawn(self, 30);
 	self.think = SUB_regen;
-
 
 	sprint(other, "You got armor\n");
 // armor touch sound
@@ -619,9 +614,9 @@ void() weapon_touch =
 	self.solid = SOLID_NOT;
 	if (deathmatch == 1)
 		self.nextthink = time + 30;
-		// Supa, SP respawning items support
-		if (!deathmatch)
-			CheckItemRespawn(self, 30);
+	// Supa, SP respawning items support
+	if (!deathmatch)
+		CheckItemRespawn(self, 30);
 
 	self.think = SUB_regen;
 
@@ -853,11 +848,9 @@ local float		best;
 // remove it in single player, or setup for respawning in deathmatch
 	self.model = string_null;
 	self.solid = SOLID_NOT;
-	// if (deathmatch == 1)
 	if (!deathmatch)
 		CheckItemRespawn(self, 30);
 	self.think = SUB_regen;
-
 
 	activator = other;
 	SUB_UseTargets();				// fire all targets / killtargets

--- a/items.qc
+++ b/items.qc
@@ -310,8 +310,6 @@ void() health_touch =
 	self.model = string_null;
 	self.solid = SOLID_NOT;
 
-	if (!deathmatch)
-		CheckItemRespawn(self, 30);
 	self.think = SUB_regen;
 
 	// Megahealth = rot down the player's super health
@@ -320,6 +318,30 @@ void() health_touch =
 		other.megahealth_rottime = time + 5;  //thanks ydrol!!!
 		other.items = other.items | IT_SUPERHEALTH;
 		self.owner = other;
+
+		// Regarding the deathmatch respawn time below: id's original
+		// code made the megahealth respawn 20 seconds after the health
+		// of the player who collected it finished rotting down.
+		// However, this mod has already got rid of the weird old
+		// megahealth behavior whereby it monitored the player who
+		// touched it, so the original respawn logic isn't applicable.
+		// As a solution, the code below uses a respawn time of 120
+		// seconds for deathmatch, because that was the worst-case
+		// scenario of id's original code (100 seconds to rot down 100
+		// health points, plus the original 20 second delay on top of
+		// that).  -- iw
+		//
+		if (!deathmatch)
+			CheckItemRespawn(self, 30);
+		else if (deathmatch == 1)  // doesn't respawn in "deathmatch 2"
+			self.nextthink = time + 120;
+	}
+	else
+	{
+		if (!deathmatch)
+			CheckItemRespawn(self, 30);
+		else if (deathmatch == 1)  // doesn't respawn in "deathmatch 2"
+			self.nextthink = time + 20;
 	}
 
 	activator = other;
@@ -375,6 +397,8 @@ void() armor_touch =
 	// Supa, SP respawning items support
 	if (!deathmatch)
 		CheckItemRespawn(self, 30);
+	else if (deathmatch == 1)  // doesn't respawn in "deathmatch 2"
+		self.nextthink = time + 20;
 	self.think = SUB_regen;
 
 	sprint(other, "You got armor\n");
@@ -612,11 +636,11 @@ void() weapon_touch =
 // remove it in single player, or setup for respawning in deathmatch
 	self.model = string_null;
 	self.solid = SOLID_NOT;
-	if (deathmatch == 1)
-		self.nextthink = time + 30;
 	// Supa, SP respawning items support
 	if (!deathmatch)
 		CheckItemRespawn(self, 30);
+	else if (deathmatch == 1)  // weapons never disappear in "deathmatch 2"
+		self.nextthink = time + 30;
 
 	self.think = SUB_regen;
 
@@ -850,6 +874,8 @@ local float		best;
 	self.solid = SOLID_NOT;
 	if (!deathmatch)
 		CheckItemRespawn(self, 30);
+	else if (deathmatch == 1)  // doesn't respawn in "deathmatch 2"
+		self.nextthink = time + 30;
 	self.think = SUB_regen;
 
 	activator = other;
@@ -1323,6 +1349,8 @@ void() powerup_touch =
 		if ((self.classname == "item_artifact_invulnerability") ||
 		    (self.classname == "item_artifact_invisibility"))
 			self.nextthink = time + 60*5;
+		else
+			self.nextthink = time + 60;
 	}
 
 	sound (other, CHAN_VOICE, self.noise, 1, ATTN_NORM);

--- a/items.qc
+++ b/items.qc
@@ -325,16 +325,17 @@ void() health_touch =
 		// However, this mod has already got rid of the weird old
 		// megahealth behavior whereby it monitored the player who
 		// touched it, so the original respawn logic isn't applicable.
-		// As a solution, the code below uses a respawn time of 120
+		// As a solution, the code below uses a respawn time of 125
 		// seconds for deathmatch, because that was the worst-case
-		// scenario of id's original code (100 seconds to rot down 100
-		// health points, plus the original 20 second delay on top of
-		// that).  -- iw
+		// scenario of id's original code (5 seconds before the player's
+		// health started to rot, plus 100 seconds to rot down 100
+		// health points, plus the original 20 second delay before the
+		// item respawned).  -- iw
 		//
 		if (!deathmatch)
 			CheckItemRespawn(self, 30);
 		else if (deathmatch == 1)  // doesn't respawn in "deathmatch 2"
-			self.nextthink = time + 120;
+			self.nextthink = time + 125;
 	}
 	else
 	{


### PR DESCRIPTION
Item respawning was unfortunately broken in deathmatch mode: the only things that would respawn were weapons, and the pentagram and ring powerups.

It seemed like most of the old deathmatch item respawn logic had been replaced by the new item respawn logic, which allows maps to set up respawnable items in single-player/coop.  However, the new code mostly didn't include logic to handle deathmatch mode.

This pull request reinstates the original item respawn logic for deathmatch mode.  It doesn't make any changes to the new logic that applies to single-player/coop.

The only intentional change from the original deathmatch behavior is the respawn logic for the megahealth, which had to be changed to fit in with the new megahealth rot behavior; the comment I've added to health_touch() explains this.