### PR TITLE
Fix a "friendly monster" bug

### DIFF
--- a/monsters.qc
+++ b/monsters.qc
@@ -191,10 +191,14 @@ if(!(self.spawnflags & 8))
 		}
 // this used to be an objerror
 		if (self.movetarget.classname == "path_corner")
+		{
 			self.th_walk ();
+		}
 		else
+		{
 			self.pausetime = 99999999;
 			self.th_stand ();
+		}
 	}
 	else
 	{
@@ -270,10 +274,14 @@ void() flymonster_start_go =
 		}
 // this used to be an objerror
 		if (self.movetarget.classname == "path_corner")
+		{
 			self.th_walk ();
+		}
 		else
+		{
 			self.pausetime = 99999999;
 			self.th_stand ();
+		}
 	}
 	else
 	{


### PR DESCRIPTION
When playing sm188_ionous, I noticed that some of the trigger-spawned
Scrags would not attack the player unless provoked: instead, they would
spawn in a bugged state where they would slowly fly towards the player
without attacking, as if they were using the player like a path_corner.

I've encountered the same bug in other mods that implement
trigger-spawned monsters.  The root cause is a typo in id's original
code, in the walkmonster_start_go() and flymonster_start_go() functions.
These functions both have code that looks like this:

    if (self.movetarget.classname == "path_corner")
        self.th_walk ();
    else
        self.pausetime = 99999999;
        self.th_stand ();

The typo is in the "else" clause.  There are no braces, so only the
first line is part of the "else".  So what the code actually does is
this:

    if (self.movetarget.classname == "path_corner")
    {
        self.th_walk ();
    }
    else
    {
        self.pausetime = 99999999;
    }
    self.th_stand ();

This may not have mattered much in the original game, but it interacts
badly with trigger-spawned monsters.  Specifically, if a trigger-spawned
monster targets a path_corner, and if it spawns so it can see the player
immediately, then self.th_walk() gets called, which puts the monster
into its "hunting" state (because it can see the player), and then
self.th_stand() gets called immediately afterwards, which takes the
monster out of its "hunting" state without properly resetting its
fields, leaving it in a bugged state.

This commit eliminates the problem by making the code do what it was
obviously meant to do, which is:

    if (self.movetarget.classname == "path_corner")
    {
        self.th_walk ();
    }
    else
    {
        self.pausetime = 99999999;
        self.th_stand ();
    }