### PR TITLE
Fix pain_target never firing in some cases

### DIFF
--- a/combat.qc
+++ b/combat.qc
@@ -175,6 +175,17 @@ void(entity targ, entity inflictor, entity attacker, float damage) T_Damage=
 // do the damage
 	targ.health = targ.health - take;
 
+// fire pain_target if appropriate
+	if ((targ.flags & FL_MONSTER) &&
+			targ.pain_target != "" &&
+			targ.health <= targ.pain_threshold)
+	{
+		oldself = self;
+		self = targ;
+		monster_pain_use ();
+		self = oldself;
+	}
+
 	if (targ.health <= 0)
 	{
 		Killed (targ, attacker);

--- a/defs.qc
+++ b/defs.qc
@@ -772,6 +772,7 @@ void(string type, string text) print_self =
 	dprint ("\n");
 };
 
+void() monster_pain_use; //dumptruck_ds
 void() SUB_UsePain; //dumptruck_ds
 .float 		pain_threshold; //dumptruck_ds
 .string 	pain_target; //dumptruck_ds

--- a/demon.qc
+++ b/demon.qc
@@ -123,10 +123,6 @@ void()	demon1_pain6	=[	$pain6,		demon1_run1	] {};
 
 void(entity attacker, float damage)	demon1_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
 	if (self.touch == Demon_JumpTouch)
 		return;
 
@@ -164,7 +160,6 @@ void() demon_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib1.mdl", self.health);
-    monster_pain_use();
 		return;
 	}
 

--- a/dog.qc
+++ b/dog.qc
@@ -197,10 +197,6 @@ void() dog_painb16	=[	$painb16 ,	dog_run1	] {};
 
 void() dog_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
 	sound (self, CHAN_VOICE, "dog/dpain1.wav", 1, ATTN_NORM);
 
 	if (random() > 0.5)
@@ -240,7 +236,6 @@ void() dog_die =
 		ThrowGib ("progs/gib3.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
 		ThrowHead ("progs/h_dog.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -213,10 +213,6 @@ void()	enf_paind19	=[	$paind19,	enf_run1	] {};
 
 void(entity attacker, float damage)	enf_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
 	local float r;
 
 	r = random ();
@@ -298,7 +294,6 @@ void() enf_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 

--- a/fish.qc
+++ b/fish.qc
@@ -146,11 +146,6 @@ void() f_pain9  =[      $pain9, f_run1 ] {ai_pain(6);};
 
 void(entity attacker, float damage)	fish_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
-
 // fish allways do pain frames
 	f_pain1 ();
 };

--- a/hknight.qc
+++ b/hknight.qc
@@ -207,7 +207,6 @@ void() hknight_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 
@@ -358,10 +357,6 @@ void() hk_idle_sound =
 
 void(entity attacker, float damage)	hknight_pain =
 {
-
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-	monster_pain_use();
-
 	if (self.pain_finished > time)
 		return;
 

--- a/knight.qc
+++ b/knight.qc
@@ -146,10 +146,6 @@ void()	knight_painb11	=[	$painb11,	knight_run1	] {};
 
 void(entity attacker, float damage)	knight_pain =
 {
-
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-	monster_pain_use();
-
 	local float r;
 
 	if (self.pain_finished > time)
@@ -225,7 +221,6 @@ void() knight_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use(); //too fast? do it anyway -- dumptruck_ds
 		return;
 	}
 

--- a/ogre.qc
+++ b/ogre.qc
@@ -314,10 +314,6 @@ void()	ogre_paine15=[	$paine15,	ogre_run1	] {};
 
 void(entity attacker, float damage)	ogre_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
 	local float	r;
 
 // don't make multiple pain sounds right after each other
@@ -395,7 +391,6 @@ void() ogre_die =
 		ThrowGib ("progs/gib3.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -89,10 +89,6 @@ void() shal_death7      =[      $death7,        shal_death7    ] {};
 
 void() shalrath_pain =
 {
-
-  if (self.health <= self.pain_threshold) //dumptruck_ds
-  monster_pain_use();
-
 	if (self.pain_finished > time)
 		return;
 
@@ -111,12 +107,10 @@ void() shalrath_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use(); //too fast for ya? do it anyway -- dumptruck_ds
 		return;
 	}
 
 	sound (self, CHAN_VOICE, "shalrath/death.wav", 1, ATTN_NORM);
-	monster_pain_use(); //no gib? do it anyway -- dumptruck_ds
 	shal_death1();
 	self.solid = SOLID_NOT;
 	// insert death sounds here

--- a/shambler.qc
+++ b/shambler.qc
@@ -278,9 +278,6 @@ void(entity attacker, float damage)	sham_pain =
 	if (self.health <= 0)
 		return;		// allready dying, don't go into pain frame
 
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-		monster_pain_use();
-
 	if (random()*400 > damage)
 		return;		// didn't flinch
 
@@ -316,13 +313,11 @@ void() sham_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 
 // regular death
 	sound (self, CHAN_VOICE, "shambler/sdeath.wav", 1, ATTN_NORM);
-	monster_pain_use();
 	sham_death1 ();
 };
 

--- a/soldier.qc
+++ b/soldier.qc
@@ -144,10 +144,6 @@ void()	army_painc13=[	$painc13,	army_run1] {};
 
 void(entity attacker, float damage)	army_pain =
 {
-
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-	monster_pain_use();
-
 	local float r;
 
 	if (self.pain_finished > time)
@@ -232,7 +228,6 @@ void() army_die =
 		ThrowGib ("progs/gib1.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib3.mdl", self.health);
-		monster_pain_use(); //too fast? do it anyway -- dumptruck_ds
 		return;
 	}
 

--- a/tarbaby.qc
+++ b/tarbaby.qc
@@ -104,9 +104,6 @@ void()	Tar_JumpTouch =
 	else
 		sound (self, CHAN_WEAPON, "blob/land1.wav", 1, ATTN_NORM);
 
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-	monster_pain_use();
-
 	if (!checkbottom(self))
 	{
 		if (self.flags & FL_ONGROUND)
@@ -183,7 +180,6 @@ void()	tbaby_die2	=[	$exp,		tbaby_run1	]
 	WriteCoord (MSG_BROADCAST, self.origin_z);
 
 	BecomeExplosion ();
-	monster_pain_use();
 };
 
 //=============================================================================

--- a/wizard.qc
+++ b/wizard.qc
@@ -348,21 +348,15 @@ void() wiz_die =
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
 		ThrowGib ("progs/gib2.mdl", self.health);
-		monster_pain_use();
 		return;
 	}
 
 	wiz_death1 ();
-	monster_pain_use();
 };
 
 
 void(entity attacker, float damage) Wiz_Pain =
 {
-
-	if (self.health <= self.pain_threshold) //dumptruck_ds
-	monster_pain_use();
-
 	sound (self, CHAN_VOICE, "wizard/wpain.wav", 1, ATTN_NORM);
 	if (random()*70 > damage)
 		return;		// didn't flinch


### PR DESCRIPTION
It was possible for most types of monster to die without firing their
pain_target.  This affected all monsters except Scrags, Shamblers,
Spawns, and Vores.

This could happen because most of the monsters' th_die() functions
called monster_pain_use() only in the case where the monster got gibbed,
and not in the case where the monster died normally.  As a result, if
the monster's health was above its pain_threshold, and the monster then
took enough damage in one go to kill it, but not gib it, the monster
wouldn't fire its pain_target.

(There are a number of ways that a monster can go from full health to
being dead-but-not-gibbed from a single damage infliction.  Perhaps the
most common is for the monster to take just the right amount of splash
damage from an explosive or quad explosive.)

There was a similar issue in some of the monsters' th_pain() functions,
where it was possible for the function to return without calling
monster_pain_use(), even when it should.

In theory, these issues could be fixed by rearranging the code in the
th_die() and th_pain() functions so that monster_pain_use() always gets
called when it should.

But it seems to me there's a better solution.

Instead of having the code involving pain_threshold and
monster_pain_use() in all of the different monsters' th_pain() and
th_die() functions, it would be simpler if there was just one single,
central place where pain_threshold is checked and where
monster_pain_use() is called.  The place to do this is in T_Damage().

This commit implements this solution, and removes the old code from all
of the th_pain() and th_die() functions, as it's no longer needed.

This should make it so that pain_target gets fired reliably in all
cases.