### PR TITLE
Fix pain_target sometimes firing multiple times

### DIFF
--- a/subs.qc
+++ b/subs.qc
@@ -400,6 +400,7 @@ if (self.pain_target)
 		t = find (t, targetname, self.pain_target);
 		if (!t)
 		{
+			self.pain_target = ""; //dumptruck_ds via Discord - thanks Spike, Snaut and QueenJazz
 			return;
 		}
 		stemp = self;
@@ -416,7 +417,6 @@ if (self.pain_target)
 		activator = act;
 	} while ( 1 );
 }
-self.pain_target = ""; //dumptruck_ds via Discord - thanks Spike, Snaut and QueenJazz
 };
 
 /*


### PR DESCRIPTION
There was a line at the end of SUB_UsePain() which set self.pain_target
to an empty string.  I assume this was to prevent it getting fired
multiple times.  However, because of where this line was positioned, it
would only be executed in the case where self.pain_target was already
empty.  In the case where self.pain_target wasn't empty, the flow of
execution would go into the do-while loop, and the only way execution
would leave the loop was via the return statement in the body of the
loop.  So, if self.pain_target wasn't empty, the code after the do-while
loop wouldn't get executed, and self.pain_target wouldn't get set to the
empty string.

The result was that a monster's pain_target could fire multiple times
from multiple damage inflictions.

This commit fixes this by moving that one line in SUB_UsePain() so that
it gets executed when appropriate.