### PR TITLE
Fix the item respawn sound in deathmatch mode

### DIFF
--- a/items.qc
+++ b/items.qc
@@ -9,11 +9,11 @@ void() SUB_regen =
 {
 	self.model = self.mdl;		// restore original model
 	self.solid = SOLID_TRIGGER;	// allow it to be touched again
-	if (!(self.spawnflags & 16384)) 			// SILENT, gb
-		{spawn_tfog (self.origin + self.particles_offset);}
+	if (deathmatch || (self.spawnflags & 16384))	// respawn DM style
+		sound (self, CHAN_VOICE, "items/itembk2.wav", 1, ATTN_NORM);	// play respawn sound
 	else
-{	sound (self, CHAN_VOICE, "items/itembk2.wav", 1, ATTN_NORM);	// play respawn sound
-}	setorigin (self, self.origin);
+		spawn_tfog (self.origin + self.particles_offset);	// play teleport sound and display particles
+	setorigin (self, self.origin);
 };
 
 // Supa, Quoth respawning items support Respawn item like in DM if 'ritem' TRUE,


### PR DESCRIPTION
From reading the progs_dump manual, it sounds like the original "item
respawn" sound effect is still supposed to be the norm in deathmatch
mode, while in single-player/coop the mapper gets to choose between two
different effects (depending on whether they set the "Respawn DM Style"
spawnflag).

However, deathmatch mode was being treated the same as
single-player/coop, meaning that items defaulted to using the "teleport"
sound and particle effects in deathmatch.

This commit makes it so that when an item respawns in deathmatch, it
always uses the original "item respawn" sound effect.