### PR TITLE
Gracefully handle trigger-spawn bugs in maps

### DIFF
--- a/monsters.qc
+++ b/monsters.qc
@@ -10,6 +10,24 @@
 //		<code>
 // };
 
+/*
+================
+monster_update_total
+
+Call this function to safely update total_monsters when the game is in
+progress.  It adds "n" to total_monsters, then notifies all clients of
+the change.  -- iw
+================
+*/
+void(float n) monster_update_total =
+{
+	total_monsters = total_monsters + n;
+
+	WriteByte (MSG_ALL, SVC_UPDATESTAT);
+	WriteByte (MSG_ALL, STAT_TOTALMONSTERS);
+	WriteLong (MSG_ALL, total_monsters);
+};
+
 /* From Preach's tutorial here: https://tomeofpreach.wordpress.com/2017/10/08/teleporting-monsters-flag/#more-2281 */
 
 //define Preach's new fields dumptruck_ds

--- a/monsters.qc
+++ b/monsters.qc
@@ -67,6 +67,36 @@ self.think = monster_teleport_go;
 self.nextthink = time + 0.1 + self.delay;
 };
 
+/*
+================
+monster_teleport_check
+
+This detects and eliminates a common map bug: a trigger-spawned monster
+which can't be activated either because it has no targetname or because
+its targetname isn't targeted by any other entity.  (This map bug would
+otherwise make it impossible for the player to get 100% kills.)  -- iw
+================
+*/
+void() monster_teleport_check =
+{
+	if (!SUB_IsTargeted ())
+	{
+		dprint ("WARNING: removed untargeted trigger-spawned ");
+		dprint (self.classname);
+		dprint (" at ");
+		dprint (vtos (self.origin));
+		dprint ("\n");
+
+		remove (self);
+		return;
+	}
+
+	// the targetname appears to be OK, so let's finish setting up the
+	// trigger-spawned monster -- iw
+	self.use = monster_teleport_delay;  // qmaster
+	monster_update_total (1);
+};
+
 float (void() monster_start_fn) monster_teleport =
 {
 if(!(self.spawnflags & 8))
@@ -83,10 +113,13 @@ self.model = "";
 self.modelindex = 0;
 self.solid = SOLID_NOT;
 self.movetype = MOVETYPE_NONE;
-//self.use = monster_teleport_go; //qmaster part 2 removes a piece of Preach's code -- dumptruck_ds
-self.use = monster_teleport_delay; //qmaster replaces above
 self.think1 = monster_start_fn;
-total_monsters = total_monsters + 1;
+
+// wait for other entities to finish spawning, then check that
+// something targets this -- iw
+self.think = monster_teleport_check;
+self.nextthink = time + 0.1;
+
 return TRUE;
 }
 

--- a/subs.qc
+++ b/subs.qc
@@ -383,6 +383,70 @@ void(string matchstring) SUB_UseName =
 };
 // ### end of Custents triggering code
 
+/*
+================
+SUB_FieldIsTargeted
+
+Return TRUE if the "fld" field of this entity is non-empty and matches
+the target (or target2/3/4 or pain_target) field of any other entity,
+otherwise return FALSE.  -- iw
+================
+*/
+float(.string fld) SUB_FieldIsTargeted =
+{
+	if (self.fld == "")
+		return FALSE;
+
+	// the following function calls are staggered to avoid the silly
+	// "return value conflict" problem with traditional compilers -- iw
+
+	if (find (world, target, self.fld) != world)
+		return TRUE;
+
+	if (find (world, target2, self.fld) != world)
+		return TRUE;
+
+	if (find (world, target3, self.fld) != world)
+		return TRUE;
+
+	if (find (world, target4, self.fld) != world)
+		return TRUE;
+
+	if (find (world, pain_target, self.fld) != world)
+		return TRUE;
+
+	return FALSE;
+};
+
+/*
+================
+SUB_IsTargeted
+
+Return TRUE if the targetname (or targetname2/3/4) field of this entity
+is non-empty and matches the target (or target2/3/4 or pain_target)
+field of any other entity, otherwise return FALSE.  -- iw
+================
+*/
+float() SUB_IsTargeted =
+{
+	// the following function calls are staggered to avoid the silly
+	// "return value conflict" problem with traditional compilers -- iw
+
+	if (SUB_FieldIsTargeted (targetname))
+		return TRUE;
+
+	if (SUB_FieldIsTargeted (targetname2))
+		return TRUE;
+
+	if (SUB_FieldIsTargeted (targetname3))
+		return TRUE;
+
+	if (SUB_FieldIsTargeted (targetname4))
+		return TRUE;
+
+	return FALSE;
+};
+
 //
 // pain_target //dumptruck_ds
 //


### PR DESCRIPTION
When a mod supports trigger-spawned monsters, a common map bug is that a map includes a trigger-spawned monster which can never be activated, either because it has no targetname or because its targetname isn't targeted by any other entity.  If left unchecked, this is a problem because it makes it impossible for the player to get 100% kills.

Out of the progs_dump maps already released, two of the sm188 maps (sm188_ing and sm188_jcr) have this bug.

This pull request makes the progs automatically detect and handle this type of map bug.  It adds in a check to see whether a trigger-spawned monster has a targetname and whether that targetname is targeted by another entity.  If this check fails, then a developer warning will be logged and the monster will be removed, before it messes up the kill count.