### PR TITLE
Fix item_health collision with BSP model entities

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -389,6 +389,10 @@ float	MSG_ONE			= 1;		// reliable to one (msg_entity)
 float	MSG_ALL			= 2;		// reliable to all
 float	MSG_INIT		= 3;		// write to the init string
 
+// known_release values -- iw
+float	KNOWN_RELEASE_NOT			= 0;
+float	KNOWN_RELEASE_FUNC_MAPJAMX	= 1;
+
 //================================================
 
 //
@@ -408,6 +412,8 @@ entity	damage_attacker;	// set by T_Damage
 float	framecount;
 
 float		skill;
+
+float	known_release;	// unique id for a release; see values above -- iw
 
 //================================================
 

--- a/items.qc
+++ b/items.qc
@@ -138,6 +138,20 @@ void() PlaceItem =
 	}
 	else
 	{
+		// The following hack for item_health was inherited from the RMQ
+		// code, and was here when the func_mapjamx maps were created.
+		// It would have been nice to remove this code entirely, because
+		// progs_dump doesn't need it, and it breaks item_health's
+		// collision with entities that have MOVETYPE_PUSH.  However,
+		// removing this code would cause some of the item_health
+		// entities in some of the func_mapjamx maps to "fall out of the
+		// level", because they're accidentally touching solid surfaces.
+		// So, to maintain backwards-compatibility, this code has been
+		// left in, but will only be run if one of the func_mapjamx maps
+		// is being played.  -- iw
+		//
+		if (known_release == KNOWN_RELEASE_FUNC_MAPJAMX)
+		{
 			if (self.classname == "item_health")	// Supa, CTF
 			{
 
@@ -147,6 +161,7 @@ void() PlaceItem =
 			self.think = RefreshHull;
 			self.nextthink = time + 0.2;
 			}
+		}
 
 		self.mdl = self.model;		// so it can be restored on respawn
 		self.flags = FL_ITEM;		// make extra wide

--- a/world.qc
+++ b/world.qc
@@ -155,6 +155,52 @@ void() main =
 };
 
 
+/*
+================
+DetectKnownRelease
+
+This detects whether the current map is from a known release for which
+a backwards-compatibility hack should be applied, and sets the
+known_release global accordingly.  -- iw
+================
+*/
+void() DetectKnownRelease =
+{
+	local string release_name;
+
+	known_release = KNOWN_RELEASE_NOT;
+	release_name = "";
+
+	if (mapname == "jamx_artistical" ||
+		mapname == "jamx_bloodshot" ||
+		mapname == "jamx_fw" ||
+		mapname == "jamx_hcm" ||
+		mapname == "jamx_ionous" ||
+		mapname == "jamx_jcr" ||
+		mapname == "jamx_kalebclark" ||
+		mapname == "jamx_mafon" ||
+		//mapname == "jamx_mugwump" ||   // dummy map
+		mapname == "jamx_naitelveni" ||
+		mapname == "jamx_newhouse" ||
+		mapname == "jamx_pinchy" ||
+		mapname == "jamx_strwrk" ||
+		mapname == "jamx_ukko" ||
+		mapname == "jamx_yoder" ||
+		(mapname == "start" && world.message == "An Unending Dusk"))
+	{
+		known_release = KNOWN_RELEASE_FUNC_MAPJAMX;
+		release_name = "func_mapjamx";
+	}
+
+	if (release_name != "")
+	{
+		dprint ("WARNING: ");
+		dprint (release_name);
+		dprint (" map detected, behaving compatibly\n");
+	}
+};
+
+
 entity	lastspawn;
 
 //=======================
@@ -171,6 +217,8 @@ World Types:
 //=======================
 void() worldspawn =
 {
+	DetectKnownRelease ();
+
 	lastspawn = world;
 	InitBodyQue ();
 


### PR DESCRIPTION
This pull request fixes a bug which affected item_health's collision
with entities that have MOVETYPE_PUSH (func_door, func_plat, func_train,
etc.).

This is the first fix I've submitted where existing maps need to be
treated specially in order to maintain backwards-compatibility.  The
reason is that some of the func_mapjamx maps accidentally relied on the
buggy behavior to prevent health boxes "falling out of the level".

I'm determined that any fixes I submit should not affect compatibility
with existing maps.  So, there are two commits:

- The first commit adds code to detect whether a func_mapjamx map is
  being played.

- The second commit fixes the item_health bug while maintaining
  backwards-compatibility with func_mapjamx.

Please see the full commit messages for the whole story.