### PR TITLE
Fix the weapon_shotgun spawnflag test

### DIFF
--- a/items.qc
+++ b/items.qc
@@ -687,9 +687,9 @@ void() weapon_shotgun =
 	self.touch = weapon_touch;
 	{
 
-		if (!self.spawnflags)
+		if (!(self.spawnflags & (2 | 4)))
 		{
-			self.spawnflags = 2;
+			self.spawnflags = self.spawnflags | 2;
 		}
 
 		if (self.spawnflags & 2)


### PR DESCRIPTION
Spawnflags 2 and 4 of weapon_shotgun allow the mapper to choose between
different models, and the manual indicates that the entity should behave
as if spawnflag 2 is set by default.

There was a check at the top of the weapon_shotgun spawn function which
would set self.spawnflags to 2 if no spawnflags were set.  However, that
didn't handle the case where spawnflags 2 and 4 weren't set but some
other spawnflag was.  In that case, spawnflag 2 wouldn't get set, so the
item would end up with neither spawnflag 2 nor spawnflag 4, so no model
would get set for the entity, making it invisible.

This commit fixes this by making the function check specifically whether
spawnflag 2 or 4 is set, and if neither is set, spawnflag 2 is added to
any existing spawnflags.