### PR TITLE
Allow "wait" to be set for elevators etc.

### DIFF
--- a/doeplats.qc
+++ b/doeplats.qc
@@ -164,7 +164,10 @@ void() elvtr_use =
 {
 	local float		tempDist, elvPos, btnPos;
 	
-	if ( (self.elevatorLastUse + 2) > time)
+	// the original DoE code had a hard-coded two second wait period;
+	// this has been changed for progs_dump so that self.wait is used
+	// instead -- iw
+	if ((self.elevatorLastUse + self.wait) > time)
 		return;
 	
 	self.elevatorLastUse = time;
@@ -421,6 +424,7 @@ PLT_TOGGLE is a plat that will change between the top and bottom each time it is
 ELEVATOR is an elevator plat. You can have as many levels as you want but they must be all the same distance away. Use elevator button entity as the trigger. 
   cnt is the number of floors
   height is the distance between floors
+  wait is the number of seconds before the elevator can be activated again after starting or stopping (default 0)
 
 START_AT_TOP is an optional flag for elevators. It just tells the elevator that it's position is the top floor. (Default is the bottom floor) USE THIS ONLY WITH ELEVATORS!
 
@@ -547,6 +551,11 @@ local float negativeHeight;
 		self.elevatorToFloor = 0;
 		self.elevatorLastUse = 0;
 		
+		// allow the mapper to set self.wait, but don't allow a negative
+		// wait period -- iw
+		if (self.wait < 0)
+			self.wait = 0;
+
 		if (self.spawnflags & START_AT_TOP)
 		{
 			self.pos1 = self.origin;

--- a/doeplats.qc
+++ b/doeplats.qc
@@ -150,8 +150,15 @@ void() elvtr_go =
 
 void() elvtr_crush =
 {
+	local float tmp;
+
 //	T_Damage (other, self, self, 1);
-	self.elevatorToFloor = self.elevatorOnFloor;
+
+	// the elevator is changing direction, so swap the floor it's coming
+	// from and the floor it's going to -- iw
+	tmp = self.elevatorOnFloor;
+	self.elevatorOnFloor = self.elevatorToFloor;
+	self.elevatorToFloor = tmp;
 	
 	elvtr_go ();
 };
@@ -164,6 +171,13 @@ void() elvtr_use =
 {
 	local float		tempDist, elvPos, btnPos;
 	
+	// the original DoE code allowed an elevator to be activated again
+	// when it was in the process of moving between floors (assuming the
+	// wait period was over); this resulted in sometimes unintuitive
+	// behavior, so, the following test prevents this -- iw
+	if (self.elevatorToFloor != self.elevatorOnFloor)
+		return;
+
 	// the original DoE code had a hard-coded two second wait period;
 	// this has been changed for progs_dump so that self.wait is used
 	// instead -- iw
@@ -547,8 +561,6 @@ local float negativeHeight;
 	}
 	else if (self.spawnflags & ELEVATOR)
 	{
-		self.elevatorOnFloor = 0;
-		self.elevatorToFloor = 0;
 		self.elevatorLastUse = 0;
 		
 		// allow the mapper to set self.wait, but don't allow a negative
@@ -562,6 +574,7 @@ local float negativeHeight;
 			self.pos2 = self.origin;
 			self.pos2_z = self.origin_z - (self.height * (self.cnt - 1));
 			self.elevatorOnFloor = self.cnt - 1;
+			self.elevatorToFloor = self.elevatorOnFloor;
 		}
 		else
 		{
@@ -569,6 +582,7 @@ local float negativeHeight;
 			self.pos2 = self.origin;
 			self.pos1_z = self.origin_z + (self.height * (self.cnt - 1));
 			self.elevatorOnFloor = 0;
+			self.elevatorToFloor = self.elevatorOnFloor;
 		}
 		
 		self.use = elvtr_use;


### PR DESCRIPTION
Further to email discussion, there are two commits in this pull request:

- The first commit makes an elevator's "wait" field control the wait
  period before it can be reactivated.

- The second commit eliminates some buggy behavior in the original code
  which was always there but would be more obvious when using a low
  "wait" value.