### PR TITLE
Implement new spawnflags ("Not in Coop" etc.)

### DIFF
--- a/ai.qc
+++ b/ai.qc
@@ -88,6 +88,9 @@ Monsters will continue walking towards the next target corner.
 */
 void() path_corner =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	movetarget_f ();
 };
 

--- a/boss.qc
+++ b/boss.qc
@@ -263,6 +263,9 @@ void() boss_awake =
 */
 void() monster_boss =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -379,6 +382,9 @@ Just for boss level.
 */
 void() event_lightning =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.use = lightning_use;
 };
 

--- a/buttons.qc
+++ b/buttons.qc
@@ -85,6 +85,9 @@ When a button is touched, it moves some distance in the direction of it's angle,
 */
 void() func_button =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (self.sounds == 0)
 	{
 		precache_sound ("buttons/airbut1.wav");

--- a/buttons.qc
+++ b/buttons.qc
@@ -85,7 +85,6 @@ When a button is touched, it moves some distance in the direction of it's angle,
 */
 void() func_button =
 {
-
 	if (self.sounds == 0)
 	{
 		precache_sound ("buttons/airbut1.wav");

--- a/client.qc
+++ b/client.qc
@@ -359,7 +359,6 @@ and toggled off and on.
 float DT_EXITOFF = 8;
 
 void() trigger_changelevel =
-
 {
 	self.use = dt_exit_toggle; //dumptruck_ds
 	if (!self.map)

--- a/client.qc
+++ b/client.qc
@@ -27,6 +27,8 @@ Use mangle instead of angle, so you can set pitch or roll as well as yaw.  'pitc
 */
 void() info_intermission =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 };
 
 
@@ -360,6 +362,9 @@ float DT_EXITOFF = 8;
 
 void() trigger_changelevel =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.use = dt_exit_toggle; //dumptruck_ds
 	if (!self.map)
 		objerror ("changelevel trigger doesn't have map");
@@ -603,6 +608,8 @@ The normal starting point for a level.
 */
 void() info_player_start =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 };
 
 
@@ -611,6 +618,8 @@ Only used on start map for the return point from an episode.
 */
 void() info_player_start2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 };
 
 
@@ -626,6 +635,8 @@ potential spawning position for deathmatch games
 */
 void() info_player_deathmatch =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 };
 
 /*QUAKED info_player_coop (1 0 1) (-16 -16 -24) (16 16 24)
@@ -633,6 +644,8 @@ potential spawning position for coop games
 */
 void() info_player_coop =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
 };
 
 /*

--- a/demon.qc
+++ b/demon.qc
@@ -364,6 +364,8 @@ void()	Demon_JumpTouch =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_demon (0 0.5 0.8) (-32 -32 -24) (32 32 64)
+*/
 void() monster_dead_demon =
 {
 	precache_model("progs/demon.mdl");

--- a/demon.qc
+++ b/demon.qc
@@ -179,6 +179,9 @@ void() Demon_MeleeAttack =
 */
 void() monster_demon1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -368,6 +371,9 @@ void()	Demon_JumpTouch =
 */
 void() monster_dead_demon =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/demon.mdl");
 	setmodel(self, "progs/demon.mdl");
 	self.frame = $death9;

--- a/doelightning.qc
+++ b/doelightning.qc
@@ -107,6 +107,9 @@ Set the LT_TOGGLE checkbox if you want the lightning shooter to continuously fir
 */
 void() ltrail_start =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.ltrailLastUsed = time;
 
 	precache_sound ("weapons/lhit.wav");
@@ -144,6 +147,9 @@ Default is 0.3 seconds.
 */
 void() ltrail_relay =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("weapons/lhit.wav");
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_BBOX;
@@ -168,6 +174,9 @@ Default is 0.3 seconds.
 */
 void() ltrail_end =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("weapons/lhit.wav");
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_BBOX;

--- a/doeplats.qc
+++ b/doeplats.qc
@@ -466,6 +466,9 @@ Set "sounds" to one of the following:
 
 void() func_new_plat =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 //local entity t;
 local float negativeHeight;
 

--- a/dog.qc
+++ b/dog.qc
@@ -365,6 +365,8 @@ void() monster_dog =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_dog (0 0.5 0.8) (-32 -32 -24) (32 32 64)
+*/
 void() monster_dead_dog =
 {
 	precache_model("progs/dog.mdl");

--- a/dog.qc
+++ b/dog.qc
@@ -328,6 +328,9 @@ float()	DogCheckAttack =
 */
 void() monster_dog =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -369,6 +372,9 @@ void() monster_dog =
 */
 void() monster_dead_dog =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/dog.mdl");
 	setmodel(self, "progs/dog.mdl");
 	self.frame = $death8;

--- a/doors.qc
+++ b/doors.qc
@@ -418,6 +418,9 @@ Key doors are allways wait -1.
 
 void() func_door =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (world.worldtype == 0)
 	{
 		precache_sound ("doors/medtry.wav");
@@ -721,6 +724,9 @@ If a secret door has a targetname, it will only be opened by it's botton or trig
 
 void () func_door_secret =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (self.sounds == 0)
 		self.sounds = 3;
 	if (self.sounds == 1)

--- a/doors.qc
+++ b/doors.qc
@@ -417,9 +417,7 @@ Key doors are allways wait -1.
 */
 
 void() func_door =
-
 {
-
 	if (world.worldtype == 0)
 	{
 		precache_sound ("doors/medtry.wav");

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -51,6 +51,9 @@ play a sound when it is used
 */
 void() play_sound_triggered =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    if (!self.noise) //dumptruck_ds
    {
        objerror ("no soundfile set in noise!\n");
@@ -88,6 +91,9 @@ play a sound on a periodic basis
 */
 void() play_sound =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    local float t;
 
    if (!self.noise) //dumptruck_ds
@@ -126,6 +132,9 @@ Keys:
 */
 void () ambient_general =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
   if (!self.noise) //dumptruck_ds
   {
       objerror ("no soundfile set in noise!\n");
@@ -168,6 +177,9 @@ void () play_tfog = //thanks Khreathor -- dumptruck_ds
 
 void() tele_fog =
 {
+  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+    return;
+
   self.use = play_tfog;
 };
 
@@ -185,6 +197,9 @@ void () play_explosion_fx = //thanks Khreathor -- dumptruck_ds
 
 void() play_explosion =
 {
+  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+    return;
+
   self.use = play_explosion_fx;
 };
 
@@ -202,6 +217,9 @@ void () play_tbaby_fx = //thanks Khreathor -- dumptruck_ds
 
 void() play_tbabyexplode =
 {
+  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+    return;
+
   precache_sound2 ("blob/death1.wav");
   self.use = play_tbaby_fx;
 };
@@ -233,6 +251,9 @@ WriteCoord (MSG_BROADCAST, self.origin_z);
 
 void () play_lavasplash =
 {
+  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+    return;
+
   if (self.noise) precache_sound (self.noise);
   precache_sound("boss1/out1.wav");
   self.use = play_lavasplash_fx;
@@ -277,6 +298,9 @@ void () play_meatspray = //-- dumptruck_ds -- thanks to Spike for helping with e
 
 void() meat_shower =
 {
+  if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+    return;
+
   self.use = play_meatspray;
 }
 /* misc gore */
@@ -291,6 +315,9 @@ deadstuff version 1.0 - tony collen - manero@canweb.net - EfNet IRC #QuakeEd or 
 */
 void() gib_head_demon =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_demon.mdl");
 	setmodel(self, "progs/h_demon.mdl");
         self.frame = 0;
@@ -310,6 +337,9 @@ void() gib_head_demon =
 */
 void() gib_head_dog =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_dog.mdl");
 	setmodel(self, "progs/h_dog.mdl");
         self.frame = 0;  //was 1 -- dumptruck_ds
@@ -329,6 +359,9 @@ void() gib_head_dog =
 */
 void() gib_head_army =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_guard.mdl");
 	setmodel(self, "progs/h_guard.mdl");
         self.frame = 0;
@@ -348,6 +381,9 @@ void() gib_head_army =
 */
 void() gib_head_hell_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_hellkn.mdl");
 	setmodel(self, "progs/h_hellkn.mdl");
         self.frame = 0;
@@ -367,6 +403,9 @@ void() gib_head_hell_knight =
 */
 void() gib_head_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_knight.mdl");
 	setmodel(self, "progs/h_knight.mdl");
         self.frame = 0;
@@ -386,6 +425,9 @@ void() gib_head_knight =
 */
 void() gib_head_enforcer =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_mega.mdl");
 	setmodel(self, "progs/h_mega.mdl");
         self.frame = 0;
@@ -405,6 +447,9 @@ void() gib_head_enforcer =
 */
 void() gib_head_ogre =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_ogre.mdl");
 	setmodel(self, "progs/h_ogre.mdl");
         self.frame = 0;
@@ -424,6 +469,9 @@ void() gib_head_ogre =
 */
 void() gib_head_player =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_player.mdl");
 	setmodel(self, "progs/h_player.mdl");
         self.frame = 0;
@@ -443,6 +491,9 @@ void() gib_head_player =
 */
 void() gib_head_shalrath =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_shal.mdl");
 	setmodel(self, "progs/h_shal.mdl");
         self.frame = 0;
@@ -462,6 +513,9 @@ void() gib_head_shalrath =
 */
 void() gib_head_shambler =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
         precache_model("progs/h_shams.mdl");
         setmodel(self, "progs/h_shams.mdl");
         self.frame = 0; //was 1, caused an error -- dumptruck_ds
@@ -481,6 +535,9 @@ void() gib_head_shambler =
 */
 void() gib_head_wizard =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/h_wizard.mdl");
 	setmodel(self, "progs/h_wizard.mdl");
         self.frame = 0;
@@ -500,6 +557,9 @@ void() gib_head_wizard =
 */
 void() gib_misc_1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/gib1.mdl");
 	setmodel(self, "progs/gib1.mdl");
         self.frame = 0;
@@ -519,6 +579,9 @@ void() gib_misc_1 =
 */
 void() gib_misc_2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/gib2.mdl");
 	setmodel(self, "progs/gib2.mdl");
         self.frame = 0;
@@ -538,6 +601,9 @@ void() gib_misc_2 =
 */
 void() gib_misc_3 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/gib3.mdl");
 	setmodel(self, "progs/gib3.mdl");
         self.frame = 0;
@@ -631,6 +697,9 @@ Falling brush upon touch
 
 void() func_fall =
 {
+    if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+        return;
+
     precache_sound("buttons/switch21.wav");
     if (self.noise) precache_sound (self.noise);
 
@@ -706,6 +775,9 @@ I used the info_notnull, but you should be able to target anything
 */
 void() misc_particle_stream =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if(!self.target)
 		objerror("misc_particle_stream with not target!");
 

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -51,7 +51,6 @@ play a sound when it is used
 */
 void() play_sound_triggered =
    {
-
    if (!self.noise) //dumptruck_ds
    {
        objerror ("no soundfile set in noise!\n");
@@ -114,7 +113,7 @@ void() play_sound =
 
  //johnfitz -- ambient_general (this is from Rubicon Rumble dev kit)
 
- /*QUAKED ambient_general (0.3 0.1 0.6) (-10 -10 -8) (10 10 8)
+/*QUAKED ambient_general (0.3 0.1 0.6) (-10 -10 -8) (10 10 8)
 Plays any looped sound
 
 Keys:
@@ -288,6 +287,8 @@ deadstuff version 1.0 - tony collen - manero@canweb.net - EfNet IRC #QuakeEd or 
 -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 */
 
+/*QUAKED gib_head_demon (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_demon =
 {
 	precache_model("progs/h_demon.mdl");
@@ -305,6 +306,8 @@ void() gib_head_demon =
 	}
 };
 
+/*QUAKED gib_head_dog (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_dog =
 {
 	precache_model("progs/h_dog.mdl");
@@ -322,6 +325,8 @@ void() gib_head_dog =
 	}
 };
 
+/*QUAKED gib_head_army (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_army =
 {
 	precache_model("progs/h_guard.mdl");
@@ -339,6 +344,8 @@ void() gib_head_army =
 	}
 };
 
+/*QUAKED gib_head_hell_knight (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_hell_knight =
 {
 	precache_model("progs/h_hellkn.mdl");
@@ -356,6 +363,8 @@ void() gib_head_hell_knight =
 	}
 };
 
+/*QUAKED gib_head_knight (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_knight =
 {
 	precache_model("progs/h_knight.mdl");
@@ -373,6 +382,8 @@ void() gib_head_knight =
 	}
 };
 
+/*QUAKED gib_head_enforcer (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_enforcer =
 {
 	precache_model("progs/h_mega.mdl");
@@ -390,6 +401,8 @@ void() gib_head_enforcer =
 	}
 };
 
+/*QUAKED gib_head_ogre (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_ogre =
 {
 	precache_model("progs/h_ogre.mdl");
@@ -407,6 +420,8 @@ void() gib_head_ogre =
 	}
 };
 
+/*QUAKED gib_head_player (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_player =
 {
 	precache_model("progs/h_player.mdl");
@@ -424,6 +439,8 @@ void() gib_head_player =
 	}
 };
 
+/*QUAKED gib_head_shalrath (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_shalrath =
 {
 	precache_model("progs/h_shal.mdl");
@@ -441,6 +458,8 @@ void() gib_head_shalrath =
 	}
 };
 
+/*QUAKED gib_head_shambler (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_shambler =
 {
         precache_model("progs/h_shams.mdl");
@@ -458,6 +477,8 @@ void() gib_head_shambler =
 	}
 };
 
+/*QUAKED gib_head_wizard (0 0.5 0.8) (-16 -16 0) (16 16 56)
+*/
 void() gib_head_wizard =
 {
 	precache_model("progs/h_wizard.mdl");
@@ -475,6 +496,8 @@ void() gib_head_wizard =
 	}
 };
 
+/*QUAKED gib_misc_1 (0 0.5 0.8) (-8 -8 -8) (8 8 8)
+*/
 void() gib_misc_1 =
 {
 	precache_model("progs/gib1.mdl");
@@ -492,6 +515,8 @@ void() gib_misc_1 =
 	}
 };
 
+/*QUAKED gib_misc_2 (0 0.5 0.8) (-8 -8 -8) (8 8 8)
+*/
 void() gib_misc_2 =
 {
 	precache_model("progs/gib2.mdl");
@@ -509,6 +534,8 @@ void() gib_misc_2 =
 	}
 };
 
+/*QUAKED gib_misc_3 (0 0.5 0.8) (-8 -8 -8) (8 8 8)
+*/
 void() gib_misc_3 =
 {
 	precache_model("progs/gib3.mdl");

--- a/dtquake.qc
+++ b/dtquake.qc
@@ -85,6 +85,9 @@ Spawnflags:
 */
 void() trigger_shake =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.targetname) objerror("trigger_shake without name");
 
 	if (self.noise) precache_sound (self.noise);

--- a/elevatr.qc
+++ b/elevatr.qc
@@ -100,6 +100,9 @@ When a button is touched, it moves some distance in the direction of it's angle,
 */
 void() func_elvtr_button =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (self.sounds == 0)
 	{
 		precache_sound ("buttons/airbut1.wav");

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -311,6 +311,9 @@ void() enf_die =
 */
 void() monster_enforcer =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -357,6 +360,9 @@ void() monster_enforcer =
 */
 void() monster_dead_enforcer =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/enforcer.mdl");
 	setmodel(self, "progs/enforcer.mdl");
 	if (self.spawnflags & 2)

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -353,6 +353,8 @@ void() monster_enforcer =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_enforcer (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() monster_dead_enforcer =
 {
 	precache_model("progs/enforcer.mdl");

--- a/fgd/progs_dump_111.fgd
+++ b/fgd/progs_dump_111.fgd
@@ -45,8 +45,12 @@
 	[
 		256 : "Not on Easy" : 0
 		512 : "Not on Normal" : 0
-		1024 : "Not on Hard" : 0
+		1024 : "Not on Hard or Nightmare" : 0
 		2048 : "Not in Deathmatch" : 0
+		4096 : "Not in Coop" : 0
+		8192 : "Not in Single Player" : 0
+		32768 : "Not on Hard Only" : 0
+		65536 : "Not on Nightmare Only" : 0
 	]
 ]
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/fgd/progs_dump_111_JACK.fgd
+++ b/fgd/progs_dump_111_JACK.fgd
@@ -36,10 +36,14 @@
 @baseclass = Appearflags [
 	spawnflags(Flags) =
 	[
-		256 : "Not in Easy" : 0
-		512 : "Not in Normal" : 0
-		1024 : "Not in Hard" : 0
+		256 : "Not on Easy" : 0
+		512 : "Not on Normal" : 0
+		1024 : "Not on Hard or Nightmare" : 0
 		2048 : "Not in Deathmatch" : 0
+		4096 : "Not in Coop" : 0
+		8192 : "Not in Single Player" : 0
+		32768 : "Not on Hard Only" : 0
+		65536 : "Not on Nightmare Only" : 0
 	]
 ]
 

--- a/fish.qc
+++ b/fish.qc
@@ -156,6 +156,9 @@ void(entity attacker, float damage)	fish_pain =
 */
 void() monster_fish =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);

--- a/func_bob.qc
+++ b/func_bob.qc
@@ -6,8 +6,7 @@
 float BOB_COLLISION = 2;		// Collision for misc_bob
 float BOB_NONSOLID = 4;			// Non solid for func_bob
 
-/*======================================================================
-QUAKED func_bob (0 .5 .8) ?
+/*QUAKED func_bob (0 .5 .8) ?
 A SOLID bmodel that gently moves back and forth
 -------- KEYS --------
 targetname : trigger entity (works with entity state system)
@@ -27,8 +26,7 @@ _shadowself : Will cast shadows on itself
 STARTOFF : Starts off and waits for trigger - DISABLED, Ripped out ESTATE System (RennyC)
 -------- NOTES --------
 A SOLID bmodel that gently moves back and forth
-
-======================================================================*/
+*/
 
 //----------------------------------------------------------------------
 void() func_bob_timer =
@@ -167,6 +165,9 @@ void() func_bob =
 };
 
 //----------------------------------------------------------------------
+
+/*QUAKED misc_bob (0 0.5 0.8) (-8 -8 -8) (8 8 8)
+*/
 void() misc_bob =
 {
 	if (self.mdl == "")

--- a/func_bob.qc
+++ b/func_bob.qc
@@ -122,6 +122,9 @@ void() func_bob_off =
 //----------------------------------------------------------------------
 void() func_bob =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.spawnflags)
 		self.spawnflags = BOB_COLLISION;
 	// Using a custom model?
@@ -170,6 +173,9 @@ void() func_bob =
 */
 void() misc_bob =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (self.mdl == "")
 		self.mdl = string_null;
 	precache_model(self.mdl);

--- a/hipcount.qc
+++ b/hipcount.qc
@@ -135,6 +135,9 @@ it specifies how high to count before reseting to zero.  Default is 10.
 
 void() func_counter =
 	{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if ( !self.wait )
 	   {
 	   self.wait = 1;
@@ -178,6 +181,9 @@ reaches the value set by count, func_oncount triggers its targets.
 
 void() func_oncount =
 	{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.count = floor( self.count );
 	if ( self.count <= 0 )
 	   {

--- a/hippart.qc
+++ b/hippart.qc
@@ -164,6 +164,9 @@ USE_COUNT when the activator is a func_counter, the field will only
 
 void() func_particlefield =
 	{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
    if ( !self.color )
 	   {
       self.color = 192;
@@ -273,6 +276,9 @@ START_OFF wall doesn't block until triggered.
 
 void() func_togglewall =
 	{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
    self.classname = "togglewall";
    self.movetype = MOVETYPE_PUSH;
    self.mdl = self.model;

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -80,6 +80,9 @@ Variable sized single use trigger that requires a key to trigger targets.  Must 
 
 void() trigger_usekey =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (world.worldtype == 0)
 	{
 		precache_sound ("doors/medtry.wav");
@@ -138,6 +141,9 @@ void() trigger_usekey =
 // */
 // void() trigger_remove =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	self.cnt = FL_CLIENT|FL_MONSTER;
 // 	if (self.spawnflags & 1)
 // 		self.cnt = self.cnt - FL_MONSTER;
@@ -210,6 +216,9 @@ set the gravity of a player
 */
 void() trigger_setgravity =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger ();
 	self.use = grav_toggle; // dumptruck_ds
 	self.touch = trigger_gravity_touch;

--- a/hknight.qc
+++ b/hknight.qc
@@ -398,6 +398,9 @@ void() hknight_melee =
 */
 void() monster_hell_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -447,6 +450,9 @@ void() monster_hell_knight =
 */
 void() monster_dead_hell_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/hknight.mdl");
 	setmodel(self, "progs/hknight.mdl");
 	if (self.spawnflags & 2)

--- a/hknight.qc
+++ b/hknight.qc
@@ -443,6 +443,8 @@ void() monster_hell_knight =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_hell_knight (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() monster_dead_hell_knight =
 {
 	precache_model("progs/hknight.mdl");

--- a/items.qc
+++ b/items.qc
@@ -50,6 +50,9 @@ prints a warning message when spawned
 */
 void() noclass =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	dprint ("noclass spawned at");
 	dprint (vtos(self.origin));
 	dprint ("\n");
@@ -250,6 +253,9 @@ void() health_touch;
 
 void() item_health =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = health_touch;
 
 	if (self.spawnflags & H_ROTTEN)
@@ -432,6 +438,9 @@ void() armor_touch =
 
 void() item_armor1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = armor_touch;
 	precache_model ("progs/armor.mdl");
 	setmodel (self, "progs/armor.mdl");
@@ -446,6 +455,9 @@ void() item_armor1 =
 
 void() item_armor2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = armor_touch;
 	precache_model ("progs/armor.mdl");
 	setmodel (self, "progs/armor.mdl");
@@ -460,6 +472,9 @@ void() item_armor2 =
 
 void() item_armorInv =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = armor_touch;
 	precache_model ("progs/armor.mdl");
 	setmodel (self, "progs/armor.mdl");
@@ -670,6 +685,9 @@ Axe
 */
 void() weapon_axe =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_axe.mdl");
 	setmodel (self, "progs/g_axe.mdl");
 	self.weapon = IT_AXE;
@@ -684,6 +702,9 @@ Shotgun
 
 void() weapon_shotgun =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = weapon_touch;
 	{
 
@@ -715,6 +736,9 @@ void() weapon_shotgun =
 
 void() weapon_supershotgun =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_shot.mdl");
 	setmodel (self, "progs/g_shot.mdl");
 	self.weapon = IT_SUPER_SHOTGUN;
@@ -730,6 +754,9 @@ void() weapon_supershotgun =
 
 void() weapon_nailgun =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_nail.mdl");
 	setmodel (self, "progs/g_nail.mdl");
 	self.weapon = IT_NAILGUN;
@@ -745,6 +772,9 @@ void() weapon_nailgun =
 
 void() weapon_supernailgun =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_nail2.mdl");
 	setmodel (self, "progs/g_nail2.mdl");
 	self.weapon = IT_SUPER_NAILGUN;
@@ -760,6 +790,9 @@ void() weapon_supernailgun =
 
 void() weapon_grenadelauncher =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_rock.mdl");
 	setmodel (self, "progs/g_rock.mdl");
 	self.weapon = 3;
@@ -775,6 +808,9 @@ void() weapon_grenadelauncher =
 
 void() weapon_rocketlauncher =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_rock2.mdl");
 	setmodel (self, "progs/g_rock2.mdl");
 	self.weapon = 3;
@@ -791,6 +827,9 @@ void() weapon_rocketlauncher =
 
 void() weapon_lightning =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/g_light.mdl");
 	setmodel (self, "progs/g_light.mdl");
 	self.weapon = 3;
@@ -908,6 +947,9 @@ float WEAPON_BIG2 = 1;
 
 void() item_shells =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = ammo_touch;
 
 	if (self.spawnflags & WEAPON_BIG2)
@@ -935,6 +977,9 @@ void() item_shells =
 
 void() item_spikes =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = ammo_touch;
 
 	if (self.spawnflags & WEAPON_BIG2)
@@ -962,6 +1007,9 @@ void() item_spikes =
 
 void() item_rockets =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = ammo_touch;
 
 	if (self.spawnflags & WEAPON_BIG2)
@@ -990,6 +1038,9 @@ void() item_rockets =
 
 void() item_cells =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = ammo_touch;
 
 	if (self.spawnflags & WEAPON_BIG2)
@@ -1023,6 +1074,9 @@ float WEAPON_SPIKES = 4;
 float WEAPON_BIG = 8;
 void() item_weapon =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = ammo_touch;
 
 	self.particles_offset = '0 0 0';
@@ -1155,6 +1209,9 @@ following:
 
 void() item_key1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (world.worldtype == 0)
 	{
 		precache_model ("progs/w_s_key.mdl");
@@ -1194,6 +1251,9 @@ following:
 
 void() item_key2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (world.worldtype == 0)
 	{
 		precache_model ("progs/w_g_key.mdl");
@@ -1277,6 +1337,9 @@ End of level sigil, pick up to end episode and return to jrstart.
 
 void() item_sigil =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.spawnflags)
 		objerror ("no spawnflags");
 
@@ -1411,6 +1474,9 @@ Player is invulnerable for 30 seconds
 */
 void() item_artifact_invulnerability =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = powerup_touch;
 
 	precache_model ("progs/invulner.mdl");
@@ -1431,6 +1497,9 @@ Player takes no damage from water or slime for 30 seconds
 */
 void() item_artifact_envirosuit =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = powerup_touch;
 
 	precache_model ("progs/suit.mdl");
@@ -1451,6 +1520,9 @@ Player is invisible for 30 seconds
 */
 void() item_artifact_invisibility =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = powerup_touch;
 
 	precache_model ("progs/invisibl.mdl");
@@ -1472,6 +1544,9 @@ The next attack from the player will do 4x damage
 */
 void() item_artifact_super_damage =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.touch = powerup_touch;
 
 	precache_model ("progs/quaddama.mdl");

--- a/knight.qc
+++ b/knight.qc
@@ -274,6 +274,8 @@ void() monster_knight =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_knight (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() monster_dead_knight =
 {
 	precache_model("progs/knight.mdl");

--- a/knight.qc
+++ b/knight.qc
@@ -237,6 +237,9 @@ void() knight_die =
 */
 void() monster_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -278,6 +281,9 @@ void() monster_knight =
 */
 void() monster_dead_knight =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/knight.mdl");
 	setmodel(self, "progs/knight.mdl");
 	if (self.spawnflags & 2)

--- a/lights.qc
+++ b/lights.qc
@@ -10,13 +10,20 @@ Used as a positional target for spotlights, etc.
 */
 void() info_null =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	remove(self);
 };
 
 /*QUAKED info_notnull (0 0.5 0) (-4 -4 -4) (4 4 4)
 Never used in the or
 */
-void() info_notnull = {};
+void() info_notnull =
+{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+};
 
 /*==========
 lightstyle_lookup
@@ -325,6 +332,9 @@ _anglescale => _anglescale
 */
 void() light =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	// default speed for fading in/out
 	if (self.speed <= 0)
 		self.speed = 0.1;
@@ -360,6 +370,9 @@ See the "light" entity for a full description.
 */
 void() light_fluoro =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	ambient_light_buzz();
 	light();
 };
@@ -373,6 +386,9 @@ See the "light" entity for a full description.
 */
 void() light_fluorospark =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.style)
 		self.style = 10;
 	ambient_flouro_buzz();
@@ -386,6 +402,9 @@ See the "light" entity for a full description.
 */
 void() light_globe =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/s_light.spr");
 	setmodel(self, "progs/s_light.spr");
 	makestatic(self);
@@ -397,6 +416,9 @@ See the "light" entity for a full description.
 */
 void() light_torch_small_walltorch =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/flame.mdl");
 	setmodel(self, "progs/flame.mdl");
 	FireAmbient ();
@@ -409,6 +431,9 @@ See the "light" entity for a full description.
 */
 void() light_flame_large_yellow =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/flame2.mdl");
 	setmodel (self, "progs/flame2.mdl");
 	self.frame = 1;
@@ -422,6 +447,9 @@ See the "light" entity for a full description.
 */
 void() light_flame_small_yellow =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/flame2.mdl");
 	setmodel(self, "progs/flame2.mdl");
 	FireAmbient ();
@@ -434,5 +462,8 @@ Identical to "light_flame_small_yellow"
 */
 void() light_flame_small_white =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	light_flame_small_yellow();
 };

--- a/misc.qc
+++ b/misc.qc
@@ -105,6 +105,8 @@
 // 	makestatic (self);
 // };
 //
+/*QUAKED FireAmbient (0.3 0.1 0.6) (-10 -10 -8) (10 10 8)
+*/
 void() FireAmbient =
 {
 	precache_sound ("ambience/fire1.wav");
@@ -200,7 +202,6 @@ void() fire_fly;
 void() fire_touch;
 void() misc_fireball =
 {
-
 	precache_model ("progs/lavaball.mdl");
 	self.classname = "fireball";
 	self.nextthink = time + (random() * 5);
@@ -634,7 +635,6 @@ testing air bubbles
 */
 
 void() air_bubbles =
-
 {
 	if (deathmatch)
 	{
@@ -746,7 +746,6 @@ Just for the debugging level.  Don't use
 */
 
 void() viewthing =
-
 {
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
@@ -785,7 +784,6 @@ void() func_wall =
 A simple entity that looks solid but lets you walk through it.
 */
 void() func_illusionary =
-
 {
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
@@ -798,7 +796,6 @@ void() func_illusionary =
 This bmodel will appear if the episode has allready been completed, so players can't reenter it.
 */
 void() func_episodegate =
-
 {
 	if (!(serverflags & self.spawnflags))
 		return;			// can still enter episode
@@ -814,7 +811,6 @@ void() func_episodegate =
 This bmodel appears unless players have all of the episode sigils.
 */
 void() func_bossgate =
-
 {
 	if ( (serverflags & 15) == 15)
 		return;		// all episodes completed
@@ -968,7 +964,6 @@ For optimzation testing, starts a lot of sounds.
 */
 
 void() misc_noisemaker =
-
 {
 	precache_sound2 ("enforcer/enfire.wav");
 	precache_sound2 ("enforcer/enfstop.wav");

--- a/misc.qc
+++ b/misc.qc
@@ -4,6 +4,9 @@
 // */
 // /void() info_null =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	remove(self);
 // };
 //
@@ -12,6 +15,8 @@
 // */
 // void() info_notnull =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
 // };
 //
 // //============================================================================
@@ -40,6 +45,9 @@
 // */
 // void() light =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	if (!self.targetname)
 // 	{	// inert light
 // 		remove(self);
@@ -65,6 +73,9 @@
 // */
 // void() light_fluoro =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	if (self.style >= 32)
 // 	{
 // 		self.use = light_use;
@@ -86,6 +97,9 @@
 // */
 // void() light_fluorospark =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	if (!self.style)
 // 		self.style = 10;
 //
@@ -100,6 +114,9 @@
 // */
 // void() light_globe =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_model ("progs/s_light.spr");
 // 	setmodel (self, "progs/s_light.spr");
 // 	makestatic (self);
@@ -109,6 +126,9 @@
 */
 void() FireAmbient =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/fire1.wav");
 // attenuate fast
 	ambientsound (self.origin, "ambience/fire1.wav", 0.5, ATTN_STATIC);
@@ -121,6 +141,9 @@ void() FireAmbient =
 // */
 // void() light_torch_small_walltorch =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_model ("progs/flame.mdl");
 // 	setmodel (self, "progs/flame.mdl");
 // 	FireAmbient ();
@@ -132,6 +155,9 @@ void() FireAmbient =
 // */
 // void() light_flame_large_yellow =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_model ("progs/flame2.mdl");
 // 	setmodel (self, "progs/flame2.mdl");
 // 	self.frame = 1;
@@ -144,6 +170,9 @@ void() FireAmbient =
 // */
 // void() light_flame_small_yellow =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_model ("progs/flame2.mdl");
 // 	setmodel (self, "progs/flame2.mdl");
 // 	FireAmbient ();
@@ -155,6 +184,9 @@ void() FireAmbient =
 // */
 // void() light_flame_small_white =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_model ("progs/flame2.mdl");
 // 	setmodel (self, "progs/flame2.mdl");
 // 	FireAmbient ();
@@ -166,6 +198,9 @@ White candle
 */
 void() light_candle =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/candle.mdl");
 	setmodel (self, "progs/candle.mdl");
 	makestatic (self);
@@ -202,6 +237,9 @@ void() fire_fly;
 void() fire_touch;
 void() misc_fireball =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/lavaball.mdl");
 	self.classname = "fireball";
 	self.nextthink = time + (random() * 5);
@@ -264,6 +302,9 @@ TESTING THING
 
 void() misc_explobox =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	local float	oldz;
 
 	self.solid = SOLID_BBOX;
@@ -296,6 +337,9 @@ Smaller exploding box, REGISTERED ONLY
 
 void() misc_explobox2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	local float	oldz;
 
 	self.solid = SOLID_BBOX;
@@ -533,6 +577,9 @@ Laser is only for REGISTERED.
 //MED 11/01/96 commented out setmovedir
 void() trap_spikeshooter =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
    SetMovedir ();
 	self.use = spikeshooter_use;
 	if (self.spawnflags & SPAWNFLAG_LASER)
@@ -583,6 +630,9 @@ Continuously fires spikes.
 */
 void() trap_shooter =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	trap_spikeshooter ();
 
 	if (self.wait == 0)
@@ -607,6 +657,9 @@ Continuously fires spikes.
 */
 void() trap_switched_shooter =
  {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
    trap_spikeshooter ();
 
 	if (self.wait == 0)
@@ -636,6 +689,9 @@ testing air bubbles
 
 void() air_bubbles =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove (self);
@@ -747,6 +803,9 @@ Just for the debugging level.  Don't use
 
 void() viewthing =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
 	precache_model ("progs/player.mdl");
@@ -772,6 +831,9 @@ This is just a solid wall if not inhibitted
 */
 void() func_wall =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_PUSH;	// so it doesn't get pushed by anything
 	self.solid = SOLID_BSP;
@@ -785,6 +847,9 @@ A simple entity that looks solid but lets you walk through it.
 */
 void() func_illusionary =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
@@ -797,6 +862,9 @@ This bmodel will appear if the episode has allready been completed, so players c
 */
 void() func_episodegate =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!(serverflags & self.spawnflags))
 		return;			// can still enter episode
 
@@ -812,6 +880,9 @@ This bmodel appears unless players have all of the episode sigils.
 */
 void() func_bossgate =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if ( (serverflags & 15) == 15)
 		return;		// all episodes completed
 	self.angles = '0 0 0';
@@ -826,6 +897,9 @@ void() func_bossgate =
 */
 void() ambient_suck_wind =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/suck1.wav");
 	ambientsound (self.origin, "ambience/suck1.wav", 1, ATTN_STATIC);
 };
@@ -834,6 +908,9 @@ void() ambient_suck_wind =
 */
 void() ambient_drone =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/drone6.wav");
 	ambientsound (self.origin, "ambience/drone6.wav", 0.5, ATTN_STATIC);
 };
@@ -842,6 +919,9 @@ void() ambient_drone =
 */
 void() ambient_flouro_buzz =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/buzz1.wav");
 	ambientsound (self.origin, "ambience/buzz1.wav", 1, ATTN_STATIC);
 };
@@ -849,6 +929,9 @@ void() ambient_flouro_buzz =
 */
 void() ambient_drip =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/drip1.wav");
 	ambientsound (self.origin, "ambience/drip1.wav", 0.5, ATTN_STATIC);
 };
@@ -856,6 +939,9 @@ void() ambient_drip =
 */
 void() ambient_comp_hum =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/comp1.wav");
 	ambientsound (self.origin, "ambience/comp1.wav", 1, ATTN_STATIC);
 };
@@ -863,6 +949,9 @@ void() ambient_comp_hum =
 */
 // void() ambient_thunder =
 // {
+// 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+// 		return;
+//
 // 	precache_sound ("ambience/thunder1.wav");
 // 	ambientsound (self.origin, "ambience/thunder1.wav", 0.5, ATTN_STATIC);
 // };
@@ -870,6 +959,9 @@ void() ambient_comp_hum =
 */
 void() ambient_light_buzz =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/fl_hum1.wav");
 	ambientsound (self.origin, "ambience/fl_hum1.wav", 0.5, ATTN_STATIC);
 };
@@ -877,6 +969,9 @@ void() ambient_light_buzz =
 */
 void() ambient_swamp1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/swamp1.wav");
 	ambientsound (self.origin, "ambience/swamp1.wav", 0.5, ATTN_STATIC);
 };
@@ -884,6 +979,9 @@ void() ambient_swamp1 =
 */
 void() ambient_swamp2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/swamp2.wav");
 	ambientsound (self.origin, "ambience/swamp2.wav", 0.5, ATTN_STATIC);
 };
@@ -900,6 +998,9 @@ void() ambient_swamp2 =
 */
 void() ambient_water1 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/water1.wav");
 	ambientsound (self.origin, "ambience/water1.wav", 1, ATTN_STATIC);
 };
@@ -907,6 +1008,9 @@ void() ambient_water1 =
 */
 void() ambient_wind2 =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("ambience/wind2.wav");
 	ambientsound (self.origin, "ambience/wind2.wav", 1, ATTN_STATIC);
 };
@@ -935,6 +1039,9 @@ void() thunder_go_boom =
 */
 void() ambient_thunder =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	//  changed from ambient to delayed sound (sounds better)
 	precache_sound ("ambience/thunder1.wav");
 	// precache_sound ("ambience/thunder2.wav"); this file in not included in the game
@@ -965,6 +1072,9 @@ For optimzation testing, starts a lot of sounds.
 
 void() misc_noisemaker =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound2 ("enforcer/enfire.wav");
 	precache_sound2 ("enforcer/enfstop.wav");
 	precache_sound2 ("enforcer/sight1.wav");

--- a/misc_model.qc
+++ b/misc_model.qc
@@ -26,6 +26,9 @@ first_frame: The starting frame of the animation.
 last_frame: The last frame of the animation.
 */
 void() misc_model = {
+    if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+        return;
+
     precache_model(self.mdl);
     setmodel(self, self.mdl);
 

--- a/misc_model.qc
+++ b/misc_model.qc
@@ -13,20 +13,18 @@
 // Forward declarations
 void() misc_model_think;
 
-/*
- * misc_model
- *
- * An entity for displaying models. A frame range can be given to animate the
- * model.
- *
- * mdl: The model to display. Can be of type mdl, bsp, or spr.
- *
- * frame: The frame to display. Can be used to offset the animation.
- *
- * first_frame: The starting frame of the animation.
- *
- * last_frame: The last frame of the animation.
- */
+/*QUAKED misc_model (0 0.5 0.8) (-8 -8 -8) (8 8 8)
+An entity for displaying models. A frame range can be given to animate the
+model.
+
+mdl: The model to display. Can be of type mdl, bsp, or spr.
+
+frame: The frame to display. Can be used to offset the animation.
+
+first_frame: The starting frame of the animation.
+
+last_frame: The last frame of the animation.
+*/
 void() misc_model = {
     precache_model(self.mdl);
     setmodel(self, self.mdl);

--- a/newflags.qc
+++ b/newflags.qc
@@ -1,0 +1,205 @@
+/*
+========================================================================
+
+NEW SPAWNFLAGS FOR ALL ENTITIES
+
+========================================================================
+
+
+This file was created for progs_dump by Ian "iw" Walshaw, August 2019.
+
+It defines functions which can be called to implement the following new
+spawnflags:
+
+	4096   Not in Coop
+	8192   Not in Single Player
+	32768  Not on Hard Only
+	65536  Not on Nightmare Only
+
+(Spawnflag 16384 is not used here because it's already used for
+something else in progs_dump.)
+
+The new spawnflags complement and complete the set of built-in
+spawnflags provided by the engine, which of course are:
+
+	256    Not on Easy
+	512    Not on Normal
+	1024   Not on Hard or Nightmare
+	2048   Not in Deathmatch
+
+In conjunction with the old spawnflags, the new spawnflags make it
+possible to exclude any entity from any combination of game modes and/or
+skill levels.
+
+
+"Not in Coop" and "Not in Single Player"
+----------------------------------------
+
+These spawnflags were inspired by Quoth 2 (Kell and Necros, 2008), which
+included two additional spawnflags for all entities: "Not in Coop" and
+"Coop Only".  In contrast to Quoth 2, the spawnflags implemented here
+are "Not in Coop" and "Not in Single Player", for symmetry with the
+built-in "Not in Deathmatch" spawnflag.
+
+
+"Not on Hard Only" and "Not on Nightmare Only"
+----------------------------------------------
+
+The set of built-in spawnflags doesn't allow a mapper to treat the Hard
+and Nightmare skill levels differently, because it only includes one
+spawnflag, 1024, which excludes an entity from both Hard and Nightmare.
+The new "Not on Hard Only" and "Not on Nightmare Only" spawnflags allow
+the mapper to exclude an entity from one of these skill levels without
+affecting the other.
+
+
+========================================================================
+*/
+
+
+// The new spawnflags.  (16384 is already used elsewhere.)
+float SPAWNFLAG_NOT_IN_COOP   = 4096;   // Not in Coop
+float SPAWNFLAG_NOT_IN_SP     = 8192;   // Not in Single Player
+float SPAWNFLAG_NOT_ON_SKILL2 = 32768;  // Not on Hard Only
+float SPAWNFLAG_NOT_ON_SKILL3 = 65536;  // Not on Nightmare Only
+
+// The number of entities inhibited by each of the new spawnflags.
+float total_not_in_coop;
+float total_not_in_sp;
+float total_not_on_skill2;
+float total_not_on_skill3;
+
+// TRUE if the developer summary has been printed.
+float done_inhibition_summary;
+
+
+/*
+================
+InitNewSpawnflags
+
+This function is intended to be called from the top of the worldspawn
+function (in world.qc).  -- iw
+================
+*/
+void() InitNewSpawnflags =
+{
+	// Initialize the global variables.
+	total_not_in_coop = 0;
+	total_not_in_sp = 0;
+	total_not_on_skill2 = 0;
+	total_not_on_skill3 = 0;
+	done_inhibition_summary = FALSE;
+
+	// In the original code, the value of the skill cvar was not copied
+	// into the skill global until the first call to StartFrame.
+	// However, the new SUB_Inhibit function will need to check what the
+	// skill is before then, so, the value is copied here.  -- iw
+	skill = cvar ("skill");
+};
+
+
+/*
+================
+SUB_Inhibit
+
+This function is intended to be called from the top of every spawn
+function, like this:
+
+	if (SUB_Inhibit ())
+		return;
+
+If the entity's spawnflags mean that it should be inhibited in the
+current game mode or on the current skill level, this function will
+remove the entity and return TRUE, otherwise this function will take no
+action and return FALSE.  -- iw
+================
+*/
+float() SUB_Inhibit =
+{
+	if (coop && (self.spawnflags & SPAWNFLAG_NOT_IN_COOP))
+	{
+		total_not_in_coop = total_not_in_coop + 1;
+		remove (self);
+		return TRUE;
+	}
+
+	if (!coop && !deathmatch && (self.spawnflags & SPAWNFLAG_NOT_IN_SP))
+	{
+		total_not_in_sp = total_not_in_sp + 1;
+		remove (self);
+		return TRUE;
+	}
+
+	// The built-in skill level spawnflags are ignored in Deathmatch, so
+	// we ignore the new ones in Deathmatch, too.  -- iw
+	if (!deathmatch)
+	{
+		if (skill == 2 && (self.spawnflags & SPAWNFLAG_NOT_ON_SKILL2))
+		{
+			total_not_on_skill2 = total_not_on_skill2 + 1;
+			remove (self);
+			return TRUE;
+		}
+
+		if (skill == 3 && (self.spawnflags & SPAWNFLAG_NOT_ON_SKILL3))
+		{
+			total_not_on_skill3 = total_not_on_skill3 + 1;
+			remove (self);
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+};
+
+
+/*
+================
+PrintInhibitionTotal
+
+This just dprints the summary line about the total number of entities
+inhibited by one of the new spawnflags (see PrintInhibitionSummary
+below).  -- iw
+================
+*/
+void(float total, string spawnflag_name) PrintInhibitionTotal =
+{
+	if (total == 0)
+		return;
+
+	dprint ("... ");
+	dprint (ftos (total));
+	dprint (" with '");
+	dprint (spawnflag_name);
+	dprint ("' spawnflag\n");
+};
+
+
+/*
+================
+PrintInhibitionSummary
+
+This function is intended to be called from the top of the StartFrame
+function (in world.qc), like this:
+
+	if (!done_inhibition_summary)
+		PrintInhibitionSummary ();
+
+The engine already logs a developer message about the number of entities
+inhibited by the built-in spawnflags; this function logs a message about
+the number of entities inhibited by the new spawnflags.  -- iw
+================
+*/
+void() PrintInhibitionSummary =
+{
+	dprint (ftos (total_not_in_coop + total_not_in_sp +
+			total_not_on_skill2 + total_not_on_skill3));
+	dprint (" additional entities inhibited by the progs.dat\n");
+
+	PrintInhibitionTotal (total_not_in_coop, "Not in Coop");
+	PrintInhibitionTotal (total_not_in_sp, "Not in Single Player");
+	PrintInhibitionTotal (total_not_on_skill2, "Not on Hard Only");
+	PrintInhibitionTotal (total_not_on_skill3, "Not on Nightmare Only");
+
+	done_inhibition_summary = TRUE;
+};

--- a/ogre.qc
+++ b/ogre.qc
@@ -454,6 +454,8 @@ void() monster_ogre =
 	walkmonster_start();
 };
 
+/*QUAKED monster_ogre_marksman (1 0 0) (-32 -32 -24) (32 32 64) Ambush
+*/
 void() monster_ogre_marksman =
 {
 	monster_ogre ();
@@ -461,6 +463,8 @@ void() monster_ogre_marksman =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_ogre (0 0.5 0.8) (-32 -32 -24) (32 32 64)
+*/
 void() monster_dead_ogre =
 {
 	precache_model("progs/ogre.mdl");

--- a/ogre.qc
+++ b/ogre.qc
@@ -416,6 +416,9 @@ void() ogre_melee =
 */
 void() monster_ogre =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -458,6 +461,9 @@ void() monster_ogre =
 */
 void() monster_ogre_marksman =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	monster_ogre ();
 };
 
@@ -467,6 +473,9 @@ void() monster_ogre_marksman =
 */
 void() monster_dead_ogre =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/ogre.mdl");
 	setmodel(self, "progs/ogre.mdl");
 	if (self.spawnflags & 2)

--- a/oldone.qc
+++ b/oldone.qc
@@ -251,6 +251,9 @@ void(entity attacker, float damage) nopain =
 */
 void() monster_oldone =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);

--- a/plats.qc
+++ b/plats.qc
@@ -145,9 +145,7 @@ Set "sounds" to one of the following:
 
 
 void() func_plat =
-
 {
-
 	if (!self.t_length)
 		self.t_length = 80;
 	if (!self.t_width)

--- a/plats.qc
+++ b/plats.qc
@@ -146,6 +146,9 @@ Set "sounds" to one of the following:
 
 void() func_plat =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.t_length)
 		self.t_length = 80;
 	if (!self.t_width)
@@ -331,6 +334,9 @@ sounds
 */
 void() func_train =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.speed)
 		self.speed = 100;
 	if (!self.target)
@@ -396,6 +402,9 @@ This is used for the final bos
 */
 void() misc_teleporttrain =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.speed)
 		self.speed = 100;
 	if (!self.target)

--- a/player.qc
+++ b/player.qc
@@ -664,6 +664,9 @@ void()	player_die_ax9	=	[	$axdeth9,	player_die_ax9	] {PlayerDead();};
 */
 void() player_dead_axe =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/player.mdl");
 	setmodel(self, "progs/player.mdl");
 	self.frame = $axdeth9;
@@ -684,6 +687,9 @@ void() player_dead_axe =
 */
 void() player_dead_face_down =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/player.mdl");
 	setmodel(self, "progs/player.mdl");
 	self.frame = $deathc14;
@@ -704,6 +710,9 @@ void() player_dead_face_down =
 */
 void() player_dead_on_side =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/player.mdl");
 	setmodel(self, "progs/player.mdl");
 	self.frame = $deathe9;

--- a/player.qc
+++ b/player.qc
@@ -660,6 +660,8 @@ void()	player_die_ax9	=	[	$axdeth9,	player_die_ax9	] {PlayerDead();};
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED player_dead_axe (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() player_dead_axe =
 {
 	precache_model("progs/player.mdl");
@@ -678,6 +680,8 @@ void() player_dead_axe =
 
 };
 
+/*QUAKED player_dead_face_down (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() player_dead_face_down =
 {
 	precache_model("progs/player.mdl");
@@ -696,6 +700,8 @@ void() player_dead_face_down =
 
 };
 
+/*QUAKED player_dead_on_side (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() player_dead_on_side =
 {
 	precache_model("progs/player.mdl");

--- a/progs.src
+++ b/progs.src
@@ -1,6 +1,7 @@
 ../progs.dat
 
 defs.qc //added fields, see comments for details
+newflags.qc //new spawnflags for all entities
 subs.qc //modified targets, triggers and killtargets
 fight.qc
 ai.qc

--- a/rotate.qc
+++ b/rotate.qc
@@ -96,6 +96,9 @@ Used as the point of rotation for rotatable objects.
 */
 void() info_rotate =
 {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
 // remove self after a little while, to make sure that entities that
 // have targeted it have had a chance to spawn
    self.nextthink = time + 2;
@@ -384,6 +387,9 @@ If "deathtype" is set with a string, this is the message that will appear when a
 
 void() func_rotate_entity =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    self.solid    = SOLID_NOT;
    self.movetype = MOVETYPE_NONE;
 
@@ -429,6 +435,9 @@ void() func_rotate_entity =
 */
 void() path_rotate =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    if ( self.noise )
       {
       precache_sound( self.noise );
@@ -784,6 +793,9 @@ void() rotate_train =
 
 void() func_rotate_train =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    if (!self.speed)
 		self.speed = 100;
 	if (!self.target)
@@ -917,6 +929,9 @@ NONBLOCKING makes the brush non-solid.  This is useless if VISIBLE is set.
 */
 void() func_movewall =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    self.angles = '0 0 0';
    self.movetype = MOVETYPE_PUSH;
    if ( self.spawnflags & NONBLOCKING )
@@ -947,6 +962,9 @@ This defines an object to be rotated.  Used as the target of func_rotate_door.
 */
 void() rotate_object =
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    self.classname = "rotate_object";
    self.solid = SOLID_NOT;
    self.movetype = MOVETYPE_NONE;
@@ -1122,6 +1140,9 @@ once door from closing again when it's blocked.
 
 void() func_rotate_door = // added slinet option - sounds 4 -- dumptruck_ds
    {
+   if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+      return;
+
    if (!self.target)
       {
       objerror( "rotate_door without target." );

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -52,6 +52,9 @@ Keys:
 */
 void () func_explobox =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.solid = SOLID_BSP;
 	self.movetype = MOVETYPE_PUSH;
 	setmodel (self, self.model);
@@ -334,6 +337,9 @@ void() break_template_setup = {
 };
 
 void () func_breakable = {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	break_template_setup();
 
 	self.solid = SOLID_BSP;
@@ -401,6 +407,9 @@ Keys:
 */
 void() trigger_ladder =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	// ignore an "up" or "down" angle (doesn't make sense for a ladder)
 	if (self.angles_y == -1 || self.angles_y == -2)
 	{
@@ -497,6 +506,9 @@ Keys:
 */
 void () func_laser =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	local entity helper;
 
 	setmodel (self, self.model);
@@ -653,6 +665,9 @@ Keys:
 */
 void() misc_sparks =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model ("progs/spark.mdl");
 	precache_sound ("dump/spark.wav");
 
@@ -722,6 +737,9 @@ Produces a continuous particle splash for waterfalls and other effects
 */
 void() misc_particles =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (!self.wait)
 		self.wait = 0.1;
 	if (!self.movedir)
@@ -781,6 +799,9 @@ void() partspray_use =
 
 void() misc_particlespray =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if ( !self.color )
 		self.color = 47;
 	if ( self.count <= 0 )

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -242,6 +242,8 @@ void() monster_shalrath =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_shalrath (0 0.5 0.8) (-32 -32 -24) (32 32 64)
+*/
 void() monster_dead_shalrath =
 {
 	precache_model("progs/shalrath.mdl");

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -203,6 +203,9 @@ void() ShalHome =
 */
 void() monster_shalrath =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -246,6 +249,9 @@ void() monster_shalrath =
 */
 void() monster_dead_shalrath =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/shalrath.mdl");
 	setmodel(self, "progs/shalrath.mdl");
 	self.frame = $death7;

--- a/shambler.qc
+++ b/shambler.qc
@@ -328,6 +328,9 @@ void() sham_die =
 */
 void() monster_shambler =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -373,6 +376,9 @@ void() monster_shambler =
 */
 void() monster_dead_shambler =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/shambler.mdl");
 	setmodel(self, "progs/shambler.mdl");
 	self.frame = $death11;

--- a/shambler.qc
+++ b/shambler.qc
@@ -369,6 +369,8 @@ void() monster_shambler =
 };
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_shambler (0 0.5 0.8) (-32 -32 -24) (32 32 64)
+*/
 void() monster_dead_shambler =
 {
 	precache_model("progs/shambler.mdl");

--- a/soldier.qc
+++ b/soldier.qc
@@ -244,6 +244,9 @@ void() army_die =
 */
 void() monster_army =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -291,6 +294,9 @@ void() monster_army =
 */
 void() monster_dead_army =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/soldier.mdl");
 	setmodel(self, "progs/soldier.mdl");
 	if (self.spawnflags & 2)

--- a/soldier.qc
+++ b/soldier.qc
@@ -287,6 +287,8 @@ void() monster_army =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_army (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() monster_dead_army =
 {
 	precache_model("progs/soldier.mdl");

--- a/tarbaby.qc
+++ b/tarbaby.qc
@@ -189,6 +189,9 @@ void()	tbaby_die2	=[	$exp,		tbaby_run1	]
 */
 void() monster_tarbaby =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);

--- a/triggers.qc
+++ b/triggers.qc
@@ -692,7 +692,7 @@ else
 	}
 };
 
-/* *QUAKED trigger_push_custom (.5 .5 .5) ? PUSH_ONCE DT_STARTOFF DT_SILENT
+/*QUAKED trigger_push_custom (.5 .5 .5) ? PUSH_ONCE DT_STARTOFF DT_SILENT
 
 dumptruck_ds
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -130,6 +130,9 @@ set "message" to text string
 */
 void() trigger_multiple =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (self.is_waiting)
 	{
 		dprint("Spawned a waiting ");
@@ -198,6 +201,9 @@ set "message" to text string
 */
 void() trigger_once =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.wait = -1;
 	trigger_multiple();
 };
@@ -209,6 +215,9 @@ This fixed size trigger cannot be touched, it can only be fired by other events.
 */
 void() trigger_relay =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.use = SUB_UseTargets;
 };
 
@@ -226,6 +235,9 @@ set "message" to text string
 */
 void() trigger_secret =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	total_secrets = total_secrets + 1;
 	self.wait = -1;
 	if (!self.message)
@@ -289,6 +301,9 @@ After the counter has been triggered "count" times (default 2), it will fire all
 */
 void() trigger_counter =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.wait = -1;
 	if (!self.count)
 		self.count = 2;
@@ -464,6 +479,9 @@ This is the destination marker for a teleporter.  It should have a "targetname" 
 */
 void() info_teleport_destination =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 // this does nothing, just serves as a target spot
 	self.mangle = self.angles;
 	self.angles = '0 0 0';
@@ -494,6 +512,9 @@ If the trigger_teleport has a targetname, it will only teleport entities when it
 */
 void() trigger_teleport =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	local vector o;
 
 	InitTrigger ();
@@ -533,6 +554,9 @@ Only used on start map.
 */
 void() trigger_setskill =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger ();
 	self.touch = trigger_skill_touch;
 };
@@ -575,6 +599,9 @@ Only fires if playing the registered version, otherwise prints the message
 */
 void() trigger_onlyregistered =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_sound ("misc/talk.wav");
 	InitTrigger ();
 	self.touch = trigger_onlyregistered_touch;
@@ -608,6 +635,9 @@ defalt dmg = 5
 */
 void() trigger_hurt =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger ();
 	self.touch = hurt_touch;
 	if (!self.dmg)
@@ -663,6 +693,9 @@ Pushes the player
 */
 void() trigger_push = //dumptruck_ds
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger ();
 	precache_sound ("ambience/windfly.wav");
 	// if (self.targetname)
@@ -710,6 +743,9 @@ Adapted from Hipnotic's func_togglewall */
 
 void() trigger_push_custom =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger();
 	self.use = push_toggle;
 	self.touch = trigger_push_touch;
@@ -762,6 +798,9 @@ and toggled off and on.
 */
 void() trigger_monsterjump =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.use = push_toggle;
 	if ( self.spawnflags & DT_STARTOFF ) // dumptruck_ds
 		 {
@@ -821,6 +860,9 @@ Use this for a 'void' area.  removes monsters, gibs, ammo, etc...  also kills pl
 */
 void() trigger_void =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	InitTrigger ();
 	self.touch = trigger_void_touch;
 };
@@ -937,6 +979,9 @@ Removes shotgun upon touch.
 */
 void() trigger_take_weapon =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	self.wait = -1;
 	trigger_multiple();
 	self.touch = take_weapon_use;

--- a/wizard.qc
+++ b/wizard.qc
@@ -413,6 +413,8 @@ void() monster_wizard =
 
 /* Scenic Dead Monster Patch stuff here from DeadStuff mod -- dumptruck_ds */
 
+/*QUAKED monster_dead_wizard (0 0.5 0.8) (-16 -16 -24) (16 16 32)
+*/
 void() monster_dead_wizard =
 {
 	precache_model("progs/wizard.mdl");

--- a/wizard.qc
+++ b/wizard.qc
@@ -374,6 +374,9 @@ void() Wiz_Missile =
 */
 void() monster_wizard =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch)
 	{
 		remove(self);
@@ -417,6 +420,9 @@ void() monster_wizard =
 */
 void() monster_dead_wizard =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	precache_model("progs/wizard.mdl");
 	setmodel(self, "progs/wizard.mdl");
 	self.frame = $death8;

--- a/world.qc
+++ b/world.qc
@@ -219,6 +219,8 @@ void() worldspawn =
 {
 	DetectKnownRelease ();
 
+	InitNewSpawnflags ();  // new spawnflags for all entities -- iw
+
 	lastspawn = world;
 	InitBodyQue ();
 
@@ -385,6 +387,9 @@ void() worldspawn =
 
 void() StartFrame =
 {
+	if (!done_inhibition_summary)  // new spawnflags for all entities -- iw
+		PrintInhibitionSummary ();
+
 	teamplay = cvar("teamplay");
 	skill = cvar("skill");
 	framecount = framecount + 1;

--- a/zombie.qc
+++ b/zombie.qc
@@ -571,6 +571,9 @@ If crucified, stick the bounding box 12 pixels back into a wall to look right.
 */
 void() monster_zombie =
 {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
 	if (deathmatch /*&& (!(self.spawnflags & SPAWN_DEAD_CRUCIFIED))*/)
 	{
 		remove(self);


### PR DESCRIPTION
Further to discussion, this pull request implements four new spawnflags
for all entities.

Please see the individual commit messages for more about how I went
about implementing this.

The rest of this description is copied-and-pasted from the comment at
the top of the new file "newflags.qc":

	4096   Not in Coop
	8192   Not in Single Player
	32768  Not on Hard Only
	65536  Not on Nightmare Only

(Spawnflag 16384 is not used here because it's already used for
something else in progs_dump.)

The new spawnflags complement and complete the set of built-in
spawnflags provided by the engine, which of course are:

	256    Not on Easy
	512    Not on Normal
	1024   Not on Hard or Nightmare
	2048   Not in Deathmatch

In conjunction with the old spawnflags, the new spawnflags make it
possible to exclude any entity from any combination of game modes and/or
skill levels.


"Not in Coop" and "Not in Single Player"
----------------------------------------

These spawnflags were inspired by Quoth 2 (Kell and Necros, 2008), which
included two additional spawnflags for all entities: "Not in Coop" and
"Coop Only".  In contrast to Quoth 2, the spawnflags implemented here
are "Not in Coop" and "Not in Single Player", for symmetry with the
built-in "Not in Deathmatch" spawnflag.


"Not on Hard Only" and "Not on Nightmare Only"
----------------------------------------------

The set of built-in spawnflags doesn't allow a mapper to treat the Hard
and Nightmare skill levels differently, because it only includes one
spawnflag, 1024, which excludes an entity from both Hard and Nightmare.
The new "Not on Hard Only" and "Not on Nightmare Only" spawnflags allow
the mapper to exclude an entity from one of these skill levels without
affecting the other.