### PR TITLE
Center a func_laser's sounds on the entity itself

### DIFF
--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -471,7 +471,9 @@ void () func_laser_use =
 		setorigin(self, '0 0 0');
 		self.spawnflags = self.spawnflags - START_OFF;
 
-		sound (activator, CHAN_VOICE, self.noise, 1, ATTN_NORM);
+		// changed for progs_dump: the laser sound is now emitted from
+		// the func_laser itself instead of from the activator -- iw
+		sound (self, CHAN_VOICE, self.noise, 1, ATTN_NORM);
 
 		if (activator.classname == "player" && self.message != "")
 		{
@@ -480,10 +482,12 @@ void () func_laser_use =
 	}
 	else
 	{
+		// changed for progs_dump: the laser sound is now emitted from
+		// the func_laser itself instead of from the activator -- iw
+		sound (self, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
+
 		setorigin(self, '0 0 9000');
 		self.spawnflags = self.spawnflags + START_OFF;
-
-		sound (activator, CHAN_VOICE, self.noise1, 1, ATTN_NORM);
 
 		if (activator.classname == "player" && self.message2 != "")
 		{


### PR DESCRIPTION
The func_laser code from the ever-awesome Rubicon 2 had a quirk
involving the "laser on" and "laser off" sounds: instead of being
emitted by the func_laser, the sound was emitted by the entity which
caused the func_laser to be turned on or off (as per the global
"activator" variable).  In the case where e.g. the player pushed
a button which turned a func_laser on or off, the player would be the
activator, therefore the player would emit the laser sound.  I suspect
that this may have been done to guarantee that the player would always
hear the "laser on" or "laser off" sound, even if e.g. the button that
targeted the func_laser was physically far away from the func_laser.

However, whatever the reason for this choice, this made func_laser
interact badly with the func_counter and func_oncount entities which
progs_dump got from Scourge of Armagon, specifically in cases where
a func_counter targeted a func_oncount which targeted a func_laser.  To
complicate matters, the symptoms of this bad interaction evidently
changed following commit 56483ab, which fixed func_counter's and
func_oncount's handling of the "activator" variable:

- Prior to commit 56483ab, func_oncount always (incorrectly) set
  "activator" to "other", which would be the previous entity in the
  target chain, i.e. the func_counter.  As a result, if that
  func_oncount targeted a func_laser, the func_laser would cause the
  func_counter to emit the "laser on" or "laser off" sound (because the
  func_counter was the activator).  This can be observed if the
  pd_lasers demo map is played with progs_dump v1.1.1.  In that map, the
  sounds of the yellow lasers are actually being emitted by the
  func_counter controlling the lasers, which is near the first set of
  yellow lasers the player comes to; it's easier to notice this if you
  compare the volume when standing near the first set of yellow lasers
  to the volume when standing near the final set of yellow lasers.

- After commit 56483ab, if the player activates a func_counter which
  targets a func_oncount, "activator" is (correctly) set to the player.
  This meant that a func_laser targeted by a func_oncount would cause
  the player to emit the "laser on" or "laser off" sound.  However, if
  the func_counter was set up to loop, this would have the unfortunate
  result that the laser sounds would follow the player around the level,
  because each new activation of the func_laser would cause it to make
  the player emit the laser sound again.

- After commit 56483ab, a func_counter with the COUNTER_START_ON
  spawnflag sets "activator" to "world", because it isn't really
  activated by anything.  In the case where a func_counter with
  COUNTER_START_ON targeted a func_oncount which targeted a func_laser,
  this meant that the func_laser would make the world entity emit the
  laser sound, with the result that the sound would seem to come from
  the map's origin.

To resolve all of these issues, this commit makes it so that the sounds
of a func_laser are emitted from the func_laser itself instead of from
its activator.