### PR TITLE
Address the remaining "fteqcc -Wall" warnings

### DIFF
--- a/items.qc
+++ b/items.qc
@@ -395,18 +395,26 @@ void() armor_touch =
 		value = 100;
 		bit = IT_ARMOR1;
 	}
-	if (self.classname == "item_armor2")
+	else if (self.classname == "item_armor2")
 	{
 		type = 0.6;
 		value = 150;
 		bit = IT_ARMOR2;
 	}
-	if (self.classname == "item_armorInv")
+	else if (self.classname == "item_armorInv")
 	{
 		type = 0.8;
 		value = 200;
 		bit = IT_ARMOR3;
 	}
+	else
+	{
+		dprint ("WARNING: armor_touch: unknown classname: ");
+		dprint (self.classname);
+		dprint ("\n");
+		return;
+	}
+
 	if (other.armortype*other.armorvalue >= type*value)
 		return;
 
@@ -643,7 +651,10 @@ void() weapon_touch =
 		other.ammo_cells = other.ammo_cells + 15;
 	}
 	else
+	{
 		objerror ("weapon_touch: unknown classname");
+		return;
+	}
 
 	sprint (other, "You got the ");
 	sprint (other, self.netname);

--- a/weapons.qc
+++ b/weapons.qc
@@ -1061,6 +1061,13 @@ void() W_ChangeWeapon =
 		if (self.ammo_cells < 1)
 			am = 1;
 	}
+	else
+	{
+		dprint ("WARNING: W_ChangeWeapon: bad impulse: ");
+		dprint (ftos (self.impulse));
+		dprint ("\n");
+		return;
+	}
 
 	self.impulse = 0;
 


### PR DESCRIPTION
This commit eliminates the remaining compiler warnings issued by fteqcc
when run with the "-Wall" option.  Each of the remaining warnings was of
the form:

    warning F302: Potentially uninitialised variable foo

... where "foo" was the name of a local variable inside a function.  The
relevant functions were:

    - armor_touch() in items.qc
    - weapon_touch() in items.qc
    - W_ChangeWeapon() in weapons.qc

In each case, the circumstance in which the local variable could end up
being used without first being initialized was a circumstance which
should never happen in practice.  For example, in armor_touch(), it
would happen if self.classname wasn't "item_armor1", "item_armor2", or
"item_armorInv".

This commit modifies each of the three functions to make it detect the
condition which shouldn't happen and return early if it does happen.
This eliminates the compiler warnings because the flow of execution can
no longer reach the point where the variable would be used without first
being initialized.

For good measure, this commit also makes it so that armor_touch() and
W_ChangeWeapon() will log a developer message if the thing which
shouldn't happen actually happens.  It wasn't necessary to add
a developer message to weapon_touch() because it already called
objerror() if the thing which shouldn't happen actually happened (it
just neglected to return afterwards, which it now does).

Now "fteqcc -Wall" compiles the progs with zero warnings.