### PR TITLE
Fix walking zombie teleportation (Zerstörer bug)

### DIFF
--- a/zombie.qc
+++ b/zombie.qc
@@ -105,7 +105,7 @@ void() zombie_cruc5     =       [       $cruc_5,                zombie_cruc6    
 void() zombie_cruc6     =       [       $cruc_6,                zombie_cruc1    ] {self.nextthink = time + 0.1 + random()*0.1;};
 
 void() zombie_walk1             =[      $walk1,         zombie_walk2    ] {
-	self.solid = SOLID_BBOX;
+	self.solid = SOLID_SLIDEBOX;
 	self.health = 60;   //so he doesn't fall
 	ai_walk(0);};
 void() zombie_walk2             =[      $walk2,         zombie_walk3    ] {ai_walk(2);};


### PR DESCRIPTION
While playtesting the stock e4m7 with progs_dump, I noticed that the
zombies which are supposed to teleport into the first big room didn't
appear.

The version of zombie.qc used in progs_dump appears to originally be
from Zerstörer: Testament of the Destroyer.  This evidently included
a bug in the zombie_walk1() function whereby self.solid got set to an
inappropriate value: SOLID_BBOX, instead of SOLID_SLIDEBOX (which is
usually used for monsters).

The reason having SOLID_BBOX instead of SOLID_SLIDEBOX prevents a zombie
from teleporting is because the teleport_touch() function will only
teleport an entity which has SOLID_SLIDEBOX (because it's only supposed
to teleport "living creatures", according to the comment).

This commit just makes that line in zombie_walk1() set self.solid to
SOLID_SLIDEBOX instead.