### PR TITLE
boss2: fix gibbed head collision

### DIFF
--- a/boss2.qc
+++ b/boss2.qc
@@ -216,35 +216,18 @@ void() GibBoss2 =
 		z = z + 96;
 	}
 
-	local entity head;
-
-	head = spawn();
-	head.origin = self.origin + '0 0 128';
-	head.velocity_z = 600; + (random() * 200);
-	head.velocity_x = -300 + (random() * 600);
-	head.velocity_y = -200 + (random() * 600);
-	head.avelocity_x = random()*120;
-	head.avelocity_y = random()*120;
-	head.avelocity_z = random()*120;
-	head.flags = self.flags - (self.flags & FL_ONGROUND);
-	head.solid = SOLID_NOT;
-	head.movetype = MOVETYPE_BOUNCE;
-	head.takedamage = DAMAGE_NO;
-	setmodel (head, "progs/h_boss.mdl");
-	setsize (head, '-67 -60 -6', '62 52 88');
-	// setsize (head, '-16 -16 0', '16 16 56');
-	head.touch = SUB_Null;
-	head.think = SUB_Remove;
-	head.nextthink = time + 120;
-
 	// killed_monsters = killed_monsters + 1; //already done in combat.qc since this is now FL_MONSTER
+	// WriteByte (MSG_ALL, SVC_KILLEDMONSTER); //already done in combat.qc since this is now FL_MONSTER -- dumptruck_ds
+
 	WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
 	WriteByte (MSG_BROADCAST, TE_LAVASPLASH);
-	// WriteByte (MSG_ALL, SVC_KILLEDMONSTER); //already done in combat.qc since this is now FL_MONSTER -- dumptruck_ds
-	WriteCoord (MSG_BROADCAST, self.origin_x);
-	WriteCoord (MSG_BROADCAST, self.origin_y);
-	WriteCoord (MSG_BROADCAST, self.origin_z);
-	remove (self);
+	WriteCoord (MSG_BROADCAST, boss_x);
+	WriteCoord (MSG_BROADCAST, boss_y);
+	WriteCoord (MSG_BROADCAST, boss_z);
+
+	self.origin = boss + '0 0 192';  // approximate position of head
+	ThrowHead ("progs/h_boss.mdl", self.health);
+	setsize (self, '-32 -32 0', '32 32 88');  // larger than most heads
 };
 
 void() boss2_die =


### PR DESCRIPTION
As discussed in email, this commit makes it so that the model used for
the boss' gibbed head will stay more-or-less centered within the
entity's bounding box while rotating, which should prevent the model
from visibly clipping into solid surfaces as it was before.

More specifically, the changes are:

    - The standard ThrowHead() function is now called to transform the
      boss into the gibbed head.  This simplifies the code and ensures
      we get the normal logic for rotation.

    - To account for the fact that ThrowHead() sets a small,
      player-sized bounding box, setsize() is called after ThrowHead()
      in order to set a more suitable, shambler-sized bounding box.

    - Before ThrowHead() is called, self.origin is set to 192 units
      above the boss' original origin so that the gibbed head will
      appear approximately where the boss' head was.

    - Because ThrowHead() transforms the boss into the gibbed head, the
      code no longer removes self.

    - I also fixed the origin for the lava splash that occurs during
      gibbing.  Previously it used self.origin, but self.origin gets
      trashed during the while loop that spawns all the gibs, so
      I changed the code to use the original origin stored in the "boss"
      vector instead.