### PR TITLE
FGDs: fix oldone/oldone2 bounding box size

### DIFF
--- a/fgd/progs_dump_113.fgd
+++ b/fgd/progs_dump_113.fgd
@@ -405,8 +405,8 @@ Default health = 80" []
 @PointClass base(Monster) size(-16 -16 -24, 16 16 24) model({ "path": ":progs/fish.mdl" }) = monster_fish : "Rotfish
 
 Default health = 25" []
-@PointClass base(Monster) size(-16 -16 -24, 16 16 32) model({ "path": ":progs/oldone.mdl" }) = monster_oldone : "Shub-Niggurath" []
-@PointClass base(Monster) size(-16 -16 -24, 16 16 32) model({ "path": ":progs/oldone.mdl", "frame": 46}) = monster_oldone2 : "Killable Shub-Niggurath" []
+@PointClass base(Monster) size(-160 -128 -24, 160 128 256) model({ "path": ":progs/oldone.mdl" }) = monster_oldone : "Shub-Niggurath" []
+@PointClass base(Monster) size(-160 -128 -24, 160 128 256) model({ "path": ":progs/oldone.mdl", "frame": 46}) = monster_oldone2 : "Killable Shub-Niggurath" []
 @PointClass base(Monster) size(-16 -16 -24, 16 16 32) studio({ "path": ":progs/zombie.mdl","skin" : skin, "frame" : frame}) = monster_zombie : "Zombie
 
 Default health = 60

--- a/fgd/progs_dump_113_JACK.fgd
+++ b/fgd/progs_dump_113_JACK.fgd
@@ -309,8 +309,8 @@ keep_ammo(integer) : "Don't drop backpack" : 0
 @PointClass base(Monster) size(-32 -32 -24, 32 32 64) studio("progs/shalrath.mdl") = monster_shalrath : "Vore a.k.a Shalrath Default health = 400" []
 @PointClass base(Monster) size(-16 -16 -24, 16 16 24) studio("progs/tarbaby.mdl") = monster_tarbaby : "Spawn Default health = 80" []
 @PointClass base(Monster) size(-16 -16 -24, 16 16 24) studio("progs/fish.mdl") = monster_fish : "Rotfish Default health = 25" []
-@PointClass base(Monster) size(-16 -16 -24, 16 16 32) studio("progs/oldone.mdl") = monster_oldone : "Shub-Niggurath" []
-@PointClass base(Monster) size(-16 -16 -24, 16 16 32) studio("progs/oldone.mdl") = monster_oldone2 : "Killable Shub-Niggurath" []
+@PointClass base(Monster) size(-160 -128 -24, 160 128 256) studio("progs/oldone.mdl") = monster_oldone : "Shub-Niggurath" []
+@PointClass base(Monster) size(-160 -128 -24, 160 128 256) studio("progs/oldone.mdl") = monster_oldone2 : "Killable Shub-Niggurath" []
 @PointClass base(Monster) size(-16 -16 -24, 16 16 32) studio("progs/zombie.mdl") = monster_zombie : "Zombie Default health = 60 If SPAWN_SLEEPING is used there must be a targetname set. The zombie will stand up when targeted. Crucified motionless zombies are silent and do not animate." //dumptruck_ds
 [
 	spawnflags(Flags) =

--- a/oldone.qc
+++ b/oldone.qc
@@ -247,7 +247,7 @@ void(entity attacker, float damage) nopain =
 //============================================================================
 
 
-/*QUAKED monster_oldone (1 0 0) (-16 -16 -24) (16 16 32)
+/*QUAKED monster_oldone (1 0 0) (-160 -128 -24) (160 128 256)
 */
 void() monster_oldone =
 {

--- a/oldone2.qc
+++ b/oldone2.qc
@@ -255,7 +255,7 @@ void() oldone2_die =
 	remove (self);
 }
 
-/*QUAKED monster_oldone2 (1 0 0) (-16 -16 -24) (16 16 32)
+/*QUAKED monster_oldone2 (1 0 0) (-160 -128 -24) (160 128 256)
 */
 void() monster_oldone2 =
 {


### PR DESCRIPTION
The bounding box which the FGD files specified for monster_oldone was
much smaller than her in-game bounding box.  I've noticed the same bug
in other editor configuration files in the past.  I assume the reason
for this is that the QUAKED comment for monster_oldone always specified
an incorrect bounding box size, and that mistake just got propagated.

This commit fixes the bounding box sizes for both monster_oldone and
monster_oldone2 in both of the FGD files, and also fixes the QUAKED
comments.