### PR TITLE
Doom style unlock

### DIFF
--- a/doors.qc
+++ b/doors.qc
@@ -4,7 +4,7 @@ float DOOR_DONT_LINK = 4;
 float DOOR_GOLD_KEY = 8;
 float DOOR_SILVER_KEY = 16;
 float DOOR_TOGGLE = 32;
-
+float DOOR_DOOM_STYLE_UNLOCK = 64;
 /*
 
 Doors are similar to buttons, but can spawn a fat trigger field around them
@@ -200,9 +200,12 @@ door_touch function.  -- iw
 */
 void() door_unlock =
 {
-	self.touch = SUB_Null;
-	if (self.enemy)
-		self.enemy.touch = SUB_Null;	// get paired door
+    if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
+    {
+    	self.touch = SUB_Null;
+    	if (self.enemy)
+	    	self.enemy.touch = SUB_Null;	// get paired door
+    }
 	door_use ();
 };
 
@@ -497,9 +500,16 @@ void() func_door =
 		self.th_die = door_killed;
 	}
 
-	if (keylock_has_key_set ())
-		self.wait = -1;
+    if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
+        self.cnt = 1    
 
+	if (keylock_has_key_set ())
+    {
+        if (!(self.spawnflags & DOOR_DOOM_STYLE_UNLOCK))
+        {
+    		self.wait = -1;
+        }
+    }
 	self.touch = door_touch;
 
 // LinkDoors can't be done until all of the doors have been spawned, so

--- a/fgd/progs_dump_113.fgd
+++ b/fgd/progs_dump_113.fgd
@@ -1378,6 +1378,7 @@ spawnflags(Flags) =
 		8 : "Gold Key required" : 0
 		16: "Silver Key required" : 0
 		32: "Toggle" : 0
+		64: "Doom-style Unlock" : 0
 	]
 ]
 

--- a/fgd/progs_dump_113_JACK.fgd
+++ b/fgd/progs_dump_113_JACK.fgd
@@ -1424,6 +1424,7 @@ Default is 0.3 seconds.
 		8 : "Gold Key required" : 0
 		16: "Silver Key required" : 0
 		32: "Toggle" : 0
+		64: "Doom-style Unlock"
 	]
 ]
 


### PR DESCRIPTION
This adds a new spawnflag to doors, "Doom-style Unlock". It makes locked doors operate normally, meaning they close after their delay and can reopen when touched with the key. 

Additionally it forces the "cnt" value to 1, so doors with the spawnflag do not remove the key from the player's inventory.