### PR TITLE
Add forgotten semicolon, fix formatting

### DIFF
--- a/doors.qc
+++ b/doors.qc
@@ -200,12 +200,12 @@ door_touch function.  -- iw
 */
 void() door_unlock =
 {
-    if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
-    {
-    	self.touch = SUB_Null;
-    	if (self.enemy)
-	    	self.enemy.touch = SUB_Null;	// get paired door
-    }
+	if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
+	{
+		self.touch = SUB_Null;
+		if (self.enemy)
+			self.enemy.touch = SUB_Null;	// get paired door
+	}
 	door_use ();
 };
 
@@ -500,16 +500,16 @@ void() func_door =
 		self.th_die = door_killed;
 	}
 
-    if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
-        self.cnt = 1    
+	if (self.spawnflags & DOOR_DOOM_STYLE_UNLOCK)
+		self.cnt = 1;
 
 	if (keylock_has_key_set ())
-    {
-        if (!(self.spawnflags & DOOR_DOOM_STYLE_UNLOCK))
-        {
-    		self.wait = -1;
-        }
-    }
+	{
+		if (!(self.spawnflags & DOOR_DOOM_STYLE_UNLOCK))
+		{
+			self.wait = -1;
+		}
+	}
 	self.touch = door_touch;
 
 // LinkDoors can't be done until all of the doors have been spawned, so


### PR DESCRIPTION
I forgot a semicolon in my previous patch. Additionally, I didn't pay attention to tabs vs spaces, so I fixed the formatting.