### PR TITLE
Homing Factor

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -532,7 +532,7 @@ float	AS_MISSILE		= 4;
 //
 .float 		pausetime;
 .entity 	movetarget;
-
+.float		homing;
 
 //
 // doors

--- a/fgd_def/pd_200_JACK.fgd
+++ b/fgd_def/pd_200_JACK.fgd
@@ -616,6 +616,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 //____TW_EDIT____
 @PointClass base(Monster, Berserk, CustomMdls) size(-32 -32 -24, 32 32 64) studio("progs/shalrath.mdl") = monster_shalrath : "Vore a.k.a Shalrath, Default health = 400"
 [
+homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/fgd_def/pd_200_TB.fgd
+++ b/fgd_def/pd_200_TB.fgd
@@ -752,6 +752,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 
 Default health = 400"
 [
+homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/fgd_def/pd_200_TB_custom_mdls.fgd
+++ b/fgd_def/pd_200_TB_custom_mdls.fgd
@@ -783,6 +783,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 
 Default health = 400"
 [
+homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -225,8 +225,11 @@ void() ShalHome =
 		self.velocity = dir * 350;
 	else
 		self.velocity = dir * 250;
-	self.nextthink = time + 0.2;
-	self.think = ShalHome;
+	if (self.homing > 0)
+	{
+		self.nextthink = time + 0.2;
+		self.think = ShalHome;
+	}
 };
 
 // void() ShalMissileTouch = --moved to misc.qc for voreball shooter --dumptruck_ds

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -348,6 +348,11 @@ void() monster_shalrath =
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 400;
 
+	if ((!self.homing && self.homing != 0) || self.homing < 0)
+	{
+		self.homing = 1;
+	}
+
 	self.th_stand = shal_stand;
 	self.th_walk = shal_walk1;
 	self.th_run = shal_run1;

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -309,6 +309,7 @@ skin(integer) : "Skin index (default 0) Use this when your custom model has more
 obit_name(string) : "When used with obit_method, this will set part of the text for a custom obituary. e.g. a Super Soldier! Using the examples here, the obituary would read: Player was eviscerated by a Super Solider!"
 obit_method(string) : "When used with obit_name, will set part of the text for a custom obituary. e.g. eviscerated - If empty, defaults to killed."
 damage_mod(float) : "USE WITH CAUTION! Multiply all damage from this monster by this number (e.g. 4 = Quad damage)"
+homing(float) : "Amount that the projectile should home in target. 1 is default, 0 is none."
 
 */
 void() monster_shalrath =

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -221,6 +221,10 @@ void() ShalHome =
 		return;
 	}
 	dir = normalize(vtemp - self.origin);
+	if (self.homing < 1 && self.homing > 0)
+	{
+		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
+	}
 	if (skill == 3)
 		self.velocity = dir * 350;
 	else

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -201,7 +201,7 @@ void() ShalMissile =
 	missile.origin = self.origin + '0 0 10';
 	missile.velocity = dir * 400;
 	missile.avelocity = '300 300 300';
-	if (self.homing > 0)
+	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
 		missile.homing = self.homing;
 		missile.nextthink = flytime + time;
@@ -221,8 +221,15 @@ void() ShalHome =
 		return;
 	}
 	dir = normalize(vtemp - self.origin);
-	if (self.homing < 1 && self.homing > 0)
+	if (self.homing < 1 && self.homing > 0) // can't do better than 100% homing
 	{
+		/*
+		This finds a vector somewhere between the vector the projectile is currently
+		travelling on and the vector that it would normally snap to for homing
+
+		homing = .25 means it will go 25% to the new direction, but keep 75% of the
+		original vector, resulting in a wider turning range.
+		*/
 		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
 	}
 	if (skill == 3)
@@ -352,7 +359,7 @@ void() monster_shalrath =
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 400;
 
-	if ((!self.homing && self.homing != 0) || self.homing < 0)
+	if ((!self.homing && self.homing != 0) || self.homing < 0) // default to normal
 	{
 		self.homing = 1;
 	}

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -201,8 +201,12 @@ void() ShalMissile =
 	missile.origin = self.origin + '0 0 10';
 	missile.velocity = dir * 400;
 	missile.avelocity = '300 300 300';
-	missile.nextthink = flytime + time;
-	missile.think = ShalHome;
+	if (self.homing > 0)
+	{
+		missile.homing = self.homing;
+		missile.nextthink = flytime + time;
+		missile.think = ShalHome;
+	}
 	missile.enemy = self.enemy;
 	missile.touch = ShalMissileTouch;
 };


### PR DESCRIPTION
This adds a `homing` property to the Shalrath that allows you to scale how much the projectiles home in on its target.

1 is full, normal homing.
0 is no homing at all.

Any value between 1 and 0 will make the projectile only able to turn by that percentage*, resulting in a wider turning radius.


\* per think, it will calculate the new direction and combine it with the current velocity, scaling both by `homing`. A `homing` value of .25 will result in the projectile taking 25% of the direction it wants to go and 75% of the direction it was already going. This makes it take many more think ticks to turn all the way, giving us the desired result of an increased turn radius.

Let me know if you need any more explanation or find any issues.