### PR TITLE
Homing factor fix

### DIFF
--- a/fgd_def/pd_201.def
+++ b/fgd_def/pd_201.def
@@ -2059,7 +2059,7 @@ spawn_angry(Choices)
 0 : "Only when trigger spawned, default behavior - not angry"
 1 : "Only when trigger spawned, set to 1 to spawn angry at player"
 
-homing(float) : "Amount that the projectile should home in target. 1 is default, 0 is none"
+homing(float) : "Amount that the projectile should home in target. Maximum 1, -1 to disable completely"
 health(integer) : "Set this to a custom health amount"
 pain_target(string) : "Fire this target when pain_threshold is reached"
 pain_threshold(integer) : "Fire pain_target when health drops below this amount"

--- a/fgd_def/pd_201_JACK.fgd
+++ b/fgd_def/pd_201_JACK.fgd
@@ -616,7 +616,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 //____TW_EDIT____
 @PointClass base(Monster, Berserk, CustomMdls) size(-32 -32 -24, 32 32 64) studio("progs/shalrath.mdl") = monster_shalrath : "Vore a.k.a Shalrath, Default health = 400"
 [
-homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
+homing(float) : "Multiplier for projectile homing, maximum 1, -1 to disable completely" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/fgd_def/pd_201_TB.fgd
+++ b/fgd_def/pd_201_TB.fgd
@@ -752,7 +752,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 
 Default health = 400"
 [
-homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
+homing(float) : "Multiplier for projectile homing, maximum 1, -1 to disable completely" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/fgd_def/pd_201_TB_custom_mdls.fgd
+++ b/fgd_def/pd_201_TB_custom_mdls.fgd
@@ -783,7 +783,7 @@ snd_misc3(string) : "Path to 2nd custom pain sound" : : "Path to 2nd custom pain
 
 Default health = 400"
 [
-homing(float) : "Multiplier for projectile homing (0 is none, 1 is normal)" : 1
+homing(float) : "Multiplier for projectile homing, maximum 1, -1 to disable completely" : 1
 snd_death(string) : "Path to custom death sound" : : "Path to custom death sound"
 snd_pain(string) : "Path to custom pain sound" : : "Path to custom pain sound"
 snd_sight(string) : "Path to custom sight sound" : : "Path to custom sight sound"

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -359,9 +359,13 @@ void() monster_shalrath =
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 400;
 
-	if ((!self.homing && self.homing != 0) || self.homing < 0) // default to normal
+	if (!self.homing) // default to normal
 	{
 		self.homing = 1;
+	}
+	else if (self.homing < 0) // disable with negative
+	{
+		self.homing = 0;
 	}
 
 	self.th_stand = shal_stand;


### PR DESCRIPTION
I got overzealous with my last pass of refactoring and messed up the default condition without noticing, so a shalrath without homing set would not have any homing factor. 

This fixes it, but makes no homing be a value of -1 instead, and 0 resets to 1.