### PR TITLE
A few new features by bmFbr

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -515,6 +515,8 @@ float	AS_MISSILE		= 4;
 
 .vector		oldorigin;		// only used by secret door
 
+.string		origmodel; // addition by bmFbr for switchable brushes
+
 .float		t_length, t_width;
 
 
@@ -590,6 +592,14 @@ float	AS_MISSILE		= 4;
 .string killtarget2;	// second target to kill
 string lastnameused;	// the targetname that was last used to trigger somthing
 
+
+//
+// switchable shadow
+// 
+.float		switchshadstyle;
+.float		shadowoff;
+.entity shadowcontroller;
+.float speed2;
 
 //===========================================================================
 
@@ -845,6 +855,11 @@ nosave float *world_sounds;  //via Spike fun times! nosave=noclobber
 void() trigger_changemusic; // dumptruck_ds
 void() onlookat_touch; // dumptruck_ds
 
+string(float num) lightstyle_fade_lookup; //addition by bmFbr for switchable shadows
+void() misc_shadowcontroller;
+void() misc_shadowcontroller_use;
+void() shadow_fade_in;
+void() shadow_fade_out;
 
 // Drake Cutscenes -- Borrowed from Zerstorer.
 .string     script;         //dhm - denotes which script to read.
@@ -900,6 +915,8 @@ float HEAL_MONSTER_ONLY	= 4;
 .string mdl_gib1;
 .string mdl_gib2;
 .string mdl_gib3;
+
+.vector mdlsz, centeroffset; // addition by bmFbr for custom model bounding box definition
 
 // Custom Model End -- dumptruck_ds
 

--- a/doors.qc
+++ b/doors.qc
@@ -63,6 +63,9 @@ void() door_hit_bottom =
 
 void() door_go_down =
 {
+	entity shadow;
+	entity oldself;
+	
 	sound (self, CHAN_VOICE, self.noise2, 1, ATTN_NORM);
 	if (self.max_health)
 	{
@@ -72,10 +75,30 @@ void() door_go_down =
 
 	self.state = STATE_DOWN;
 	SUB_CalcMove (self.pos1, self.speed, door_hit_bottom);
+	
+	if(self.switchshadstyle) {
+		shadow = self.shadowcontroller;
+		oldself = self;
+		self = shadow;
+		
+		if(oldself.spawnflags & DOOR_START_OPEN) {
+			shadow_fade_out();
+			shadow.shadowoff = 1;
+		} else {
+			shadow_fade_in();
+			shadow.shadowoff = 0;
+		}
+		
+		self = oldself;
+		
+	}
 };
 
 void() door_go_up =
 {
+	entity shadow;
+	entity oldself;
+	
 	if (self.state == STATE_UP)
 		return;		// allready going up
 
@@ -90,6 +113,22 @@ void() door_go_up =
 	SUB_CalcMove (self.pos2, self.speed, door_hit_top);
 
 	SUB_UseTargets();
+	
+	if(self.switchshadstyle) {
+		shadow = self.shadowcontroller;
+		oldself = self;
+		self = shadow;
+		
+		if(oldself.spawnflags & DOOR_START_OPEN) {
+			shadow_fade_in();
+			shadow.shadowoff = 0;
+		} else {
+			shadow_fade_out();
+			shadow.shadowoff = 1;
+		}
+		
+		self = oldself;
+	}
 };
 
 
@@ -411,6 +450,8 @@ void() func_door =
 
 	local string default_noise1;
 	local string default_noise2;
+	entity shadow;
+	entity oldself;
 
 // self.noise3 and self.noise4 can now be overridden by the mapper, but
 // will be set to default values in keylock_init if necessary -- iw
@@ -517,6 +558,29 @@ void() func_door =
 // the sizes can be detected properly.
 	self.think = LinkDoors;
 	self.nextthink = self.ltime + 0.1;
+	
+	// creates a shadow controller entity for the door if it has switchable shadows
+	if(self.switchshadstyle) {
+		
+		shadow = spawn();
+		
+		self.shadowcontroller = shadow;
+		
+		shadow.classname = "misc_shadowcontroller";
+		shadow.switchshadstyle = self.switchshadstyle;
+		shadow.speed = vlen(self.pos2 - self.pos1) / self.speed;
+		
+		if(self.spawnflags & DOOR_START_OPEN) shadow.spawnflags = 1;
+		else shadow.spawnflags = 0;
+		
+		
+		oldself = self;
+		
+		self = shadow;
+		misc_shadowcontroller();
+		
+		self = oldself;
+	}
 };
 
 /*

--- a/fgd_def/pd_200_TB.fgd
+++ b/fgd_def/pd_200_TB.fgd
@@ -60,6 +60,8 @@
 		1 : "Reset to shotgun, axe, and 25 shells"
 		2 : "Reset to axe only"
 	]
+	_bounce(integer) : "Bounce lights" : 0 : "1 enables bounce lighting, disabled by default."
+	_bouncestyled(integer) : "Bounce styled lights" : 0 : "1 makes styled lights bounce (e.g. flickering or switchable lights), default is 0, they do not bounce."
 	_sunlight(integer) : "Sunlight" : 0 : "Set the brightness of the sunlight coming from an unseen sun in the sky. Sky brushes (or more accurately bsp leafs with sky contents) will emit sunlight at an angle specified by the _sun_mangle key. Default 0"
 	_sun_mangle(string) : "Sun mangle (Yaw pitch roll)" : "0 -90 0" : "Specifies the direction of sunlight using yaw(x), pitch(y) and roll(z) in degrees. Yaw specifies the angle around the Z-axis from 0 to 359 degrees and pitch specifies the angle from 90 (straight up) to -90 (straight down). Roll has no effect, so use any value (e.g. 0). Default is straight down (0 -90 0)"
 	_sunlight_penumbra(integer) : "Sunlight penumbra in degrees" : 0 : "Specifies the penumbra width, in degrees, of sunlight. Useful values are 3-4 for a gentle soft edge, or 10-20+ for more diffuse sunlight. Default is 0"
@@ -1132,6 +1134,17 @@ spawnflags(Flags) =
 		_phong_angle(integer) : "Phong shading angle" :  : "Enables phong shading on faces of this model with a custom angle. Adjacent faces with normals this many degrees apart (or less) will be smoothed. Consider setting '_anglescale' to '1' on lights or worldspawn to make the effect of phong shading more visible. Use the '-phongdebug' command-line flag to save the interpolated normals to the lightmap for previewing (use 'r_lightmap 1' or 'gl_lightmaps 1' in your engine to preview.)"
 	]
 
+@baseclass = SwitchShadow [
+	_switchableshadow(choices) : "Switchable shadow" : 0 : "Enables a switchable shadow that can be controlled with a targeting misc_shadowcontroller." = [
+		0: "No"
+		1: "Yes"
+	]
+]
+
+@baseclass = Shadow [
+	_shadow(integer) : "Shadows" :  : "If n is 1, this model will cast shadows on other models and itself (i.e. '_shadow' implies '_shadowself'). Note that this doesn’t magically give Quake dynamic lighting powers, so the shadows will not move if the model moves. Func_detail ONLY - If set to -1, light will pass through this brush model. Default 0"
+	_shadowself(integer) : "Self Shadow" :  : "If n is 1, this model will cast shadows on itself if one part of the model blocks the light from another model surface. This can be a better compromise for moving models than full shadowing. Default 0"
+]
 
 @SolidClass color(128 128 230)base(ModelLight) = func_detail : "Detail brush. Ignored by vis so can speed up compile times consideratbly. Also allows you to set new compiler lighting options on brushes. DOES NOT SEAL MAPS FROM VOID" []
 
@@ -1231,7 +1244,7 @@ spawnflags(Flags) =
 // misc
 //
 
-@SolidClass base(Appearflags) = func_illusionary : "Static nonsolid model"  []
+@SolidClass base(Appearflags, ModelLight) = func_illusionary : "Static nonsolid model"  []
 
 @PointClass base(Appearflags) color(0 150 220) = air_bubbles : "Air bubbles" []
 @PointClass base(Appearflags, Targetname) =
@@ -1497,6 +1510,10 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 		32: "Toggle" : 0
 		64: "Doom-style Unlock" : 0
 	]
+	_switchableshadow(choices) : "Switchable shadow" : 0 : "Enables dynamic shadows that fade on/off when the door moves." = [
+		0: "No"
+		1: "Yes"
+	]
 ]
 
 @SolidClass base(Appearflags, Targetname, Target) = func_door_secret : "Secret door"
@@ -1533,8 +1550,25 @@ Originally unused in the game. Plays the sound of thunder at a random interval. 
 // 	]
 // ]
 
-@SolidClass base(Appearflags, Targetname, Effects) = func_wall : "Wall, starts animation when triggered (if supporting texture).
+@SolidClass base(Appearflags, Targetname, Effects, ModelLight, SwitchShadow) = func_wall : "Wall, starts animation when triggered (if supporting texture).
 Effects will require an origin brush to work properly (see func_fall2 in manual for details)" []
+
+@SolidClass base(Appearflags, Targetname, Effects, ModelLight) = func_togglevisiblewall : "A bmodel which you can toggle its visibility. Behaves much like a traditional func_wall in any other way, but you can target it to toggle visible/invisible.
+If the entity has a switchable shadow it also toggles automatically (no need for a shadow controller)."
+[
+	spawnflags(flags) =
+	[
+		1 : "Start Off" : 0
+		2 : "Non-solid" : 0
+	]
+	_switchableshadow(choices) : "Switchable shadow" : 0 : "Enables dynamic shadows that toggle on/off with the entity" = [
+		0: "No"
+		1: "Yes"
+	]
+
+]
+
+@SolidClass base(Targetname, Shadow, SwitchShadow) = func_shadow : "An invisible, non-solid brush entity that can be used to cast shadows. " []
 
 @SolidClass base(Appearflags, Targetname) = func_explobox : "An exploding brush entity.  Works just like misc_explobox.
 
@@ -1624,6 +1658,22 @@ dmg is the amount of damage to cause when touched."
 	]
 ]
 
+
+@PointClass base(Appearflags, Targetname) size(16 16 16) color(64 64 64) = misc_shadowcontroller : "Controls switchable shadows on any bmodel entity (except doors). 
+Target this entity to toggle the shadows on/off with a fading animation.
+
+Targeted bmodel must have _switchableshadow set to 1."
+[
+	target(target_destination) : "Target"
+	speed(integer) : "Fade-in speed" : 0.5 : "Controls the time in seconds it takes to fade the shadow in. Setting it to -1 disables fading."
+	speed2(integer) : "Fade-out speed" :  : "Same as 'speed' but for the fade out animation. If unset it uses the same value as 'speed'."
+	spawnflags(flags) =
+	[
+		1 : "Shadow start off" : 0
+
+	]
+]
+
 @PointClass base(Appearflags, Targetname, Target) size(16 16 16) color(255 200 0) = misc_sparks : "Produces a burst of yellow sparks at random intervals. If targeted, it will toggle between on or off.  If it targets a light, that light will flash along with each burst of sparks. Note: targeted lights should be set to START_OFF. Set sounds key to 1 for built-in spark sound effect or target a play_sound_triggered for a custom sound."
 [
 	wait(integer) : "is the average delay between bursts (variance is 1/2 wait). Default is 2."
@@ -1691,6 +1741,7 @@ NOTE: To have a continuous stream use a func_counter as the target, then set the
 	wait(string) : "Wait before reset" : "1"
 	delay(string) : "Delay before trigger"
 	message(string) : "Message"
+	_shadow(integer) : "Shadows"
 ]
 @SolidClass base(Angle, Appearflags, Targetname, Target) = func_elvtr_button : "Button for use with func_new_plat" //modified by dumptruck_ds to add Target
 [
@@ -2023,6 +2074,13 @@ NOTE: set angle value to 0 if using angles key to rotate mdls"
 	last_frame(integer)
 	speed(integer) : "Speed" : 10
 	angles(integer) : "set 'angle' to 0 if this is used"
+	mdlsz(integer) : "Entity size (x y z)"
+	centeroffset(integer) : "Model center offset"
+	spawnflags(flags) =
+		[
+			1: "Gravity" : 0
+			2: "Solid" : 0
+		]
 ]
 
 ///////////////////////////////////////////////////////////////////////

--- a/fgd_def/pd_200_TB.fgd
+++ b/fgd_def/pd_200_TB.fgd
@@ -1660,11 +1660,13 @@ dmg is the amount of damage to cause when touched."
 
 
 @PointClass base(Appearflags, Targetname) size(16 16 16) color(64 64 64) = misc_shadowcontroller : "Controls switchable shadows on any bmodel entity (except doors). 
-Target this entity to toggle the shadows on/off with a fading animation.
+Target this entity to toggle the shadows on/off with an optional fading animation.
 
-Targeted bmodel must have _switchableshadow set to 1."
+Targeted bmodel must have _switchableshadow set to 1.
+
+If the target entity changes its default behavior when 'targetname' is set (such as breakables), you can target the entity's 'targetname2' key."
 [
-	target(target_destination) : "Target"
+	target(target_destination) : "Target" : : "Target with _switchableshadow enabled."
 	speed(integer) : "Fade-in speed" : 0.5 : "Controls the time in seconds it takes to fade the shadow in. Setting it to -1 disables fading."
 	speed2(integer) : "Fade-out speed" :  : "Same as 'speed' but for the fade out animation. If unset it uses the same value as 'speed'."
 	spawnflags(flags) =

--- a/fgd_def/pd_200_TB.fgd
+++ b/fgd_def/pd_200_TB.fgd
@@ -2053,6 +2053,18 @@ NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds sho
 @PointClass size(16 16 16) = misc_noisemaker : "Debug entity: continuously plays enforcer sounds" []
 @PointClass size(16 16 16) = viewthing : "Debug entity: fake player model" []
 
+
+@PointClass base(Appearflags, Targetname) = misc_infight : "Makes 'target' monster angry at 'target2'.
+
+By default, the infighting doesn't start mutually, that is, 'target2' monster will only get mad back at 'target' after it's been attacked.
+
+If you want to make them angry at each other instantly, you can set the spawnflag 'Mutual hate'."
+[
+	target(target_destination) : "The monster who will get angry."
+	target2(target_destination) : "Who target will get angry at."
+	spawnflags(flags) = [ 1: "Mutual hate" : 0 ]
+]
+
 ///////////////////////////////////////////////////////////
 //dumptruck’s additions via Joshua Skelton’s Quake Tools///
 ///////////////////////////////////////////////////////////

--- a/misc.qc
+++ b/misc.qc
@@ -1249,6 +1249,65 @@ void() misc_shadowcontroller = {
 	self.use = misc_shadowcontroller_use;
 }
 
+ 
+/*
+misc_infight
+
+target = monster that gets mad
+target2 = who target1 will be angry at
+
+spawnflag 1 = mutual hate, both targets get angry at each other instantly
+*/
+
+float INFIGHT_MUTUAL = 1;
+
+void(entity t1, entity t2) make_angry_at =
+{
+	if (t2.health > 0 && t1.health > 0) { // checks if targets are alive
+		if (t1.enemy.classname == "player")
+			t1.oldenemy = t1.enemy;
+		t1.enemy = t2;
+
+		entity oself = self;
+		self = t1; // FoundTarget() only acts on self
+		FoundTarget();
+		self = oself;
+	}
+};
+
+void() misc_infight_use = 
+{
+	local entity	t1, t2;
+
+	t1 = find(world, targetname, self.target);
+	t2 = find(world, targetname, self.target2);
+	
+	if (!t1)
+	{
+		dprint("[misc_infight] Cannot find target\n");
+		return;
+	}
+	if (!t2)
+	{
+		dprint("[misc_infight] Cannot find target2\n");
+		return;
+	}
+	
+	make_angry_at(t1, t2);
+	
+	if (self.spawnflags & INFIGHT_MUTUAL)
+		make_angry_at(t2, t1);
+};
+
+void() misc_infight = 
+{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+	
+	self.use = misc_infight_use;
+};
+
+
 
 
 

--- a/misc.qc
+++ b/misc.qc
@@ -971,6 +971,7 @@ void() func_wall =
 	self.solid = SOLID_BSP;
 	self.use = func_wall_use;
 	setmodel (self, self.model);
+	
 };
 
 
@@ -985,8 +986,23 @@ void() func_illusionary =
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
-	setmodel (self, self.model);
-	makestatic (self);
+	
+	if(!(self.spawnflags & 2)) setmodel (self, self.model);
+	
+	// switchable shadow code for backwards compatibility with bmfbrsp2
+	// deprecated, use func_shadow instead
+	if(self.switchshadstyle) { 
+		if(self.spawnflags & 4) {
+			lightstyle(self.switchshadstyle, "a");
+			self.shadowoff = 0;
+		} else {
+			lightstyle(self.switchshadstyle, "m");
+			self.shadowoff = 1;
+		}
+	}
+	else if(!(self.spawnflags & 1)){
+		makestatic (self);
+	}
 };
 
 /*QUAKED func_episodegate (0 .5 .8) ? E1 E2 E3 E4
@@ -1023,6 +1039,235 @@ void() func_bossgate =
 	self.use = func_wall_use;
 	setmodel (self, self.model);
 };
+
+/*****************
+func_togglevisiblewall
+A bmodel which you can toggle its visibility. Behaves much like a traditional func_wall in any other way,
+but you can target it to toggle visible/invisible.
+If the entity has a switchable shadow it also toggles.
+******************/
+
+float TOGGLEVISWALL_STARTOFF = 1;
+float TOGGLEVISWALL_NOTSOLID = 2;
+
+void() func_togglevisiblewall_use =
+{
+	if(!self.state) {
+		if(!(self.spawnflags & TOGGLEVISWALL_NOTSOLID)) {
+			self.solid = SOLID_BSP;
+			self.movetype = MOVETYPE_PUSH;
+		}
+		setmodel (self, self.origmodel);
+		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "a");
+		self.state = 1;
+	} else {
+		
+		self.solid = SOLID_NOT;
+		self.movetype = MOVETYPE_NONE;
+		setmodel (self, "");
+		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "m");
+		self.state = 0;
+	}
+
+};
+
+void() func_togglevisiblewall =
+{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
+	self.angles = '0 0 0';
+	self.use = func_togglevisiblewall_use;
+	
+	self.origmodel = self.model;
+	
+	if(self.spawnflags & TOGGLEVISWALL_STARTOFF) self.state = 1;
+	else self.state = 0;
+	
+	if(self.spawnflags & TOGGLEVISWALL_NOTSOLID) {
+		self.solid = SOLID_NOT;
+		self.movetype = MOVETYPE_NONE;
+	}
+	
+	func_togglevisiblewall_use();
+
+};
+
+/*****************
+func_shadow
+An invisible bmodel that only casts a shadow.
+
+******************/
+
+float FUNCSHADOW_STARTOFF = 1;
+
+
+
+void() func_shadow = {
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+
+	self.angles = '0 0 0';
+	self.movetype = MOVETYPE_NONE;
+	self.solid = SOLID_NOT;
+	
+	self.modelindex = 0;
+	self.model = "";
+	
+}
+
+
+
+
+/********************
+misc_shadowcontroller
+
+Controls switchable shadows on any bmodel entity (except doors).
+Target entity must have set _switchableshadow set to 1, and either _shadow, _shadowself/_selfshadow, or _shadowworldonly also set to 1.
+"speed" controls the time in seconds it takes to fade in/out. Default is 0.5, and setting it to -1 disables fading. 
+
+*********************/
+
+float SHADOWCONTROLLER_STARTOFF = 1;
+
+void() shadow_fade_out =
+{
+	
+	
+	if (self.count < 0)
+		self.count = 0;
+	if (self.count > 12)
+		self.count = 12;
+	
+	dprint(ftos(self.count));dprint("\n");
+	
+	lightstyle(self.switchshadstyle, lightstyle_fade_lookup(self.count));
+	self.count = self.count + self.dmg;
+	if (self.count > 12)
+		return;
+
+	self.think = shadow_fade_out;
+	self.nextthink = time + self.delay;
+};
+
+void() shadow_fade_in =
+{
+	
+	if (self.count < 0)
+		self.count = 0;
+	if (self.count > 12)
+		self.count = 12;
+	
+	dprint(ftos(self.count));dprint("\n");
+	
+	lightstyle(self.switchshadstyle, lightstyle_fade_lookup(self.count));
+	self.count = self.count - self.dmg;
+	if (self.count < 0)
+		return;
+	
+	
+	self.think = shadow_fade_in;
+	self.nextthink = time + self.delay;
+	
+};
+
+void(float speed) misc_shadowcontroller_setsteps = {
+	// self.delay -> time between steps
+	// self.dmg -> step size
+	if(speed >= 0.24) {
+		self.delay = (speed/12);
+		self.dmg = 1;
+	}
+	else if(speed >= 0.12) {
+		self.delay = (speed/6);
+		self.dmg = 2;
+	}
+	else if(speed >= 0.06) {
+		self.delay = (speed/3);
+		self.dmg = 4;
+	}
+	else if(speed >= 0.04) {
+		self.delay = (speed/2);
+		self.dmg = 6;
+	}
+	else {
+		self.delay = 0;
+		self.dmg = 12;
+	}
+	
+}
+
+void() misc_shadowcontroller_use = {
+
+	if(self.shadowoff) {
+		dprint("Fade in:\n");
+		
+		misc_shadowcontroller_setsteps(self.speed);
+		
+		shadow_fade_in();
+		
+		self.shadowoff = 0;
+	} else {
+		dprint("Fade out:\n");
+		
+		misc_shadowcontroller_setsteps(self.speed2);
+		
+		shadow_fade_out();
+		
+		self.shadowoff = 1;
+	}
+}
+
+void() misc_shadowcontroller = {
+	entity t1;
+	
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+	
+	
+	// doesn't search for a target if switchshadstyle is already set
+	// used for built-in shadow controllers
+	if(!self.switchshadstyle) {
+		t1 = find(world, targetname, self.target);
+		
+		// we need to find only the first target entity with switchable shadows set, since shadow lightstyles are bound by targetname
+		while(t1 != world && !t1.switchshadstyle) {
+			t1 = find(t1, targetname, self.target);
+		}
+		
+		if(t1 == world) {
+			dprint("\b[misc_shadowcontroller]\b _switchableshadow not set in target ");dprint(self.target);dprint("\n");
+			return;
+		}
+		
+		self.switchshadstyle = t1.switchshadstyle;
+	}
+	
+	if(!self.speed) self.speed = 0.5;
+	if(!self.speed2) self.speed2 = self.speed;
+	
+	if(self.spawnflags & SHADOWCONTROLLER_STARTOFF) {
+		lightstyle(self.switchshadstyle, "m");
+		
+		self.shadowoff = 1;
+		self.count = 12;
+		
+		misc_shadowcontroller_setsteps(self.speed2);
+	}
+	else {
+		lightstyle(self.switchshadstyle, "a");
+		self.shadowoff = 0;
+		self.count = 0;
+		misc_shadowcontroller_setsteps(self.speed);
+	}
+	
+	
+
+	self.use = misc_shadowcontroller_use;
+}
+
+
+
 
 //============================================================================
 /*QUAKED ambient_suck_wind (0.3 0.1 0.6) (-10 -10 -8) (10 10 8) X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY

--- a/misc.qc
+++ b/misc.qc
@@ -971,7 +971,6 @@ void() func_wall =
 	self.solid = SOLID_BSP;
 	self.use = func_wall_use;
 	setmodel (self, self.model);
-
 };
 
 
@@ -1087,7 +1086,7 @@ void() func_togglevisiblewall =
 /*****************
 func_shadow
 
-An invisible bmodel that only casts a shadow.
+An invisible bmodel that can be used to only cast shadows.
 
 ******************/
 
@@ -1112,7 +1111,8 @@ misc_shadowcontroller
 Controls switchable shadows on any bmodel entity (except doors).
 Target entity must have set _switchableshadow set to 1.
 
-speed: Controls the time in seconds it takes to fade in/out. Default is 0.5, and setting it to -1 disables fading.
+speed: Controls the time in seconds it takes to fade the shadow in. Default is 0.5, and setting it to -1 disables fading.
+speed2: Same as 'speed' but for the fade out animation. If unset it's the same value as 'speed'.
 spawnflag 1: target shadow starts as disabled
 
 *********************/

--- a/misc.qc
+++ b/misc.qc
@@ -986,23 +986,8 @@ void() func_illusionary =
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
-
-	if(!(self.spawnflags & 2)) setmodel (self, self.model);
-
-	// switchable shadow code for backwards compatibility with bmfbrsp2
-	// deprecated, use func_shadow instead
-	if(self.switchshadstyle) {
-		if(self.spawnflags & 4) {
-			lightstyle(self.switchshadstyle, "a");
-			self.shadowoff = 0;
-		} else {
-			lightstyle(self.switchshadstyle, "m");
-			self.shadowoff = 1;
-		}
-	}
-	else if(!(self.spawnflags & 1)){
-		makestatic (self);
-	}
+	setmodel (self, self.model);
+	makestatic (self);
 };
 
 /*QUAKED func_episodegate (0 .5 .8) ? E1 E2 E3 E4

--- a/misc.qc
+++ b/misc.qc
@@ -971,7 +971,7 @@ void() func_wall =
 	self.solid = SOLID_BSP;
 	self.use = func_wall_use;
 	setmodel (self, self.model);
-	
+
 };
 
 
@@ -986,12 +986,12 @@ void() func_illusionary =
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
-	
+
 	if(!(self.spawnflags & 2)) setmodel (self, self.model);
-	
+
 	// switchable shadow code for backwards compatibility with bmfbrsp2
 	// deprecated, use func_shadow instead
-	if(self.switchshadstyle) { 
+	if(self.switchshadstyle) {
 		if(self.spawnflags & 4) {
 			lightstyle(self.switchshadstyle, "a");
 			self.shadowoff = 0;
@@ -1042,9 +1042,14 @@ void() func_bossgate =
 
 /*****************
 func_togglevisiblewall
+
 A bmodel which you can toggle its visibility. Behaves much like a traditional func_wall in any other way,
 but you can target it to toggle visible/invisible.
 If the entity has a switchable shadow it also toggles.
+
+spawnflag 1: starts invisible
+spawnflag 2: set brush as non-solid
+
 ******************/
 
 float TOGGLEVISWALL_STARTOFF = 1;
@@ -1061,7 +1066,7 @@ void() func_togglevisiblewall_use =
 		if(self.switchshadstyle) lightstyle(self.switchshadstyle, "a");
 		self.state = 1;
 	} else {
-		
+
 		self.solid = SOLID_NOT;
 		self.movetype = MOVETYPE_NONE;
 		setmodel (self, "");
@@ -1078,30 +1083,28 @@ void() func_togglevisiblewall =
 
 	self.angles = '0 0 0';
 	self.use = func_togglevisiblewall_use;
-	
+
 	self.origmodel = self.model;
-	
+
 	if(self.spawnflags & TOGGLEVISWALL_STARTOFF) self.state = 1;
 	else self.state = 0;
-	
+
 	if(self.spawnflags & TOGGLEVISWALL_NOTSOLID) {
 		self.solid = SOLID_NOT;
 		self.movetype = MOVETYPE_NONE;
 	}
-	
+
 	func_togglevisiblewall_use();
 
 };
 
+
 /*****************
 func_shadow
+
 An invisible bmodel that only casts a shadow.
 
 ******************/
-
-float FUNCSHADOW_STARTOFF = 1;
-
-
 
 void() func_shadow = {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
@@ -1110,12 +1113,11 @@ void() func_shadow = {
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_NONE;
 	self.solid = SOLID_NOT;
-	
+
 	self.modelindex = 0;
 	self.model = "";
-	
-}
 
+}
 
 
 
@@ -1123,8 +1125,10 @@ void() func_shadow = {
 misc_shadowcontroller
 
 Controls switchable shadows on any bmodel entity (except doors).
-Target entity must have set _switchableshadow set to 1, and either _shadow, _shadowself/_selfshadow, or _shadowworldonly also set to 1.
-"speed" controls the time in seconds it takes to fade in/out. Default is 0.5, and setting it to -1 disables fading. 
+Target entity must have set _switchableshadow set to 1.
+
+speed: Controls the time in seconds it takes to fade in/out. Default is 0.5, and setting it to -1 disables fading.
+spawnflag 1: target shadow starts as disabled
 
 *********************/
 
@@ -1132,15 +1136,13 @@ float SHADOWCONTROLLER_STARTOFF = 1;
 
 void() shadow_fade_out =
 {
-	
-	
 	if (self.count < 0)
 		self.count = 0;
 	if (self.count > 12)
 		self.count = 12;
-	
+
 	dprint(ftos(self.count));dprint("\n");
-	
+
 	lightstyle(self.switchshadstyle, lightstyle_fade_lookup(self.count));
 	self.count = self.count + self.dmg;
 	if (self.count > 12)
@@ -1152,23 +1154,21 @@ void() shadow_fade_out =
 
 void() shadow_fade_in =
 {
-	
 	if (self.count < 0)
 		self.count = 0;
 	if (self.count > 12)
 		self.count = 12;
-	
+
 	dprint(ftos(self.count));dprint("\n");
-	
+
 	lightstyle(self.switchshadstyle, lightstyle_fade_lookup(self.count));
 	self.count = self.count - self.dmg;
 	if (self.count < 0)
 		return;
-	
-	
+
 	self.think = shadow_fade_in;
 	self.nextthink = time + self.delay;
-	
+
 };
 
 void(float speed) misc_shadowcontroller_setsteps = {
@@ -1194,64 +1194,64 @@ void(float speed) misc_shadowcontroller_setsteps = {
 		self.delay = 0;
 		self.dmg = 12;
 	}
-	
+
 }
 
 void() misc_shadowcontroller_use = {
 
 	if(self.shadowoff) {
 		dprint("Fade in:\n");
-		
+
 		misc_shadowcontroller_setsteps(self.speed);
-		
+
 		shadow_fade_in();
-		
+
 		self.shadowoff = 0;
 	} else {
 		dprint("Fade out:\n");
-		
+
 		misc_shadowcontroller_setsteps(self.speed2);
-		
+
 		shadow_fade_out();
-		
+
 		self.shadowoff = 1;
 	}
 }
 
 void() misc_shadowcontroller = {
 	entity t1;
-	
+
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
-	
-	
+
+
 	// doesn't search for a target if switchshadstyle is already set
 	// used for built-in shadow controllers
 	if(!self.switchshadstyle) {
 		t1 = find(world, targetname, self.target);
-		
+
 		// we need to find only the first target entity with switchable shadows set, since shadow lightstyles are bound by targetname
 		while(t1 != world && !t1.switchshadstyle) {
 			t1 = find(t1, targetname, self.target);
 		}
-		
+
 		if(t1 == world) {
 			dprint("\b[misc_shadowcontroller]\b _switchableshadow not set in target ");dprint(self.target);dprint("\n");
 			return;
 		}
-		
+
 		self.switchshadstyle = t1.switchshadstyle;
 	}
-	
+
 	if(!self.speed) self.speed = 0.5;
 	if(!self.speed2) self.speed2 = self.speed;
-	
+
 	if(self.spawnflags & SHADOWCONTROLLER_STARTOFF) {
 		lightstyle(self.switchshadstyle, "m");
-		
+
 		self.shadowoff = 1;
 		self.count = 12;
-		
+
 		misc_shadowcontroller_setsteps(self.speed2);
 	}
 	else {
@@ -1260,8 +1260,6 @@ void() misc_shadowcontroller = {
 		self.count = 0;
 		misc_shadowcontroller_setsteps(self.speed);
 	}
-	
-	
 
 	self.use = misc_shadowcontroller_use;
 }

--- a/misc.qc
+++ b/misc.qc
@@ -1213,12 +1213,24 @@ void() misc_shadowcontroller = {
 	// doesn't search for a target if switchshadstyle is already set
 	// used for built-in shadow controllers
 	if(!self.switchshadstyle) {
-		t1 = find(world, targetname, self.target);
 
 		// we need to find only the first target entity with switchable shadows set, since shadow lightstyles are bound by targetname
+		
+		
+		t1 = find(world, targetname2, self.target);
+		
 		while(t1 != world && !t1.switchshadstyle) {
-			t1 = find(t1, targetname, self.target);
+			t1 = find(t1, targetname2, self.target);
 		}
+		
+		if(t1 == world) {
+			t1 = find(world, targetname, self.target);
+			
+			while(t1 != world && !t1.switchshadstyle) {
+				t1 = find(t1, targetname, self.target);
+			}
+		}
+
 
 		if(t1 == world) {
 			dprint("\b[misc_shadowcontroller]\b _switchableshadow not set in target ");dprint(self.target);dprint("\n");

--- a/misc_model.qc
+++ b/misc_model.qc
@@ -28,19 +28,46 @@ first_frame: The starting frame of the animation.
 
 last_frame: The last frame of the animation.
 */
+
+float MISC_MODEL_GRAVITY = 1;
+float MISC_MODEL_SOLID = 2;
+
 void() misc_model = {
     if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
         return;
-
+		
+	if(!self.centeroffset) self.centeroffset = '0 0 0';
+	if(!self.mdlsz) self.mdlsz = '32 32 32';
+	
+	vector vmin, vmax;
+	
+	vmin_x = self.centeroffset_x - (self.mdlsz_x / 2);
+	vmin_y = self.centeroffset_y - (self.mdlsz_y / 2);
+	vmin_z = self.centeroffset_z - (self.mdlsz_z / 2);
+	
+	vmax_x = self.centeroffset_x + (self.mdlsz_x / 2);
+	vmax_y = self.centeroffset_y + (self.mdlsz_y / 2);
+	vmax_z = self.centeroffset_z + (self.mdlsz_z / 2);
+	
+	if(self.spawnflags & MISC_MODEL_SOLID) self.solid = SOLID_BBOX;
+	else self.solid = SOLID_NOT;
+	
+	if(self.spawnflags & MISC_MODEL_GRAVITY) self.movetype = MOVETYPE_TOSS;
+	else self.movetype = MOVETYPE_NONE;
+	
     precache_model(self.mdl);
     setmodel(self, self.mdl);
 
+	setsize(self, vmin, vmax);
+	
+	
     if (!self.frame) {
         self.frame = self.first_frame;
     }
 
-    // Only animate if given a frame range
-    if (!self.last_frame) {
+    // Make static (not animate) if not given a frame range, and not affected by gravity
+	//changed by bmFbr
+    if (!self.last_frame && !(self.spawnflags & MISC_MODEL_GRAVITY)) {
         makestatic(self);
         return;
     }

--- a/subs.qc
+++ b/subs.qc
@@ -295,28 +295,28 @@ void() SUB_UseTargets =
 		t = find(world, targetname, self.killtarget);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname, self.killtarget);
 		}
 		t = find(world, targetname2, self.killtarget);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname2, self.killtarget);
 		}
 		t = find(world, targetname3, self.killtarget);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname3, self.killtarget);
 		}
 		t = find(world, targetname4, self.killtarget);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname4, self.killtarget);
 		}
@@ -330,28 +330,28 @@ void() SUB_UseTargets =
 		t = find(world, targetname, self.killtarget2);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname, self.killtarget2);
 		}
 		t = find(world, targetname2, self.killtarget2);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname2, self.killtarget2);
 		}
 		t = find(world, targetname3, self.killtarget2);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname3, self.killtarget2);
 		}
 		t = find(world, targetname4, self.killtarget2);
 		while(t != world)
 		{
-			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "m");
 			remove(t);
 			t = find(t, targetname4, self.killtarget2);
 		}

--- a/subs.qc
+++ b/subs.qc
@@ -295,24 +295,28 @@ void() SUB_UseTargets =
 		t = find(world, targetname, self.killtarget);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname, self.killtarget);
 		}
 		t = find(world, targetname2, self.killtarget);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname2, self.killtarget);
 		}
 		t = find(world, targetname3, self.killtarget);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname3, self.killtarget);
 		}
 		t = find(world, targetname4, self.killtarget);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname4, self.killtarget);
 		}
@@ -326,24 +330,28 @@ void() SUB_UseTargets =
 		t = find(world, targetname, self.killtarget2);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname, self.killtarget2);
 		}
 		t = find(world, targetname2, self.killtarget2);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname2, self.killtarget2);
 		}
 		t = find(world, targetname3, self.killtarget2);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname3, self.killtarget2);
 		}
 		t = find(world, targetname4, self.killtarget2);
 		while(t != world)
 		{
+			if(t.switchshadstyle) lightstyle(t.switchshadstyle, "a");
 			remove(t);
 			t = find(t, targetname4, self.killtarget2);
 		}

--- a/triggers.qc
+++ b/triggers.qc
@@ -1015,65 +1015,6 @@ void() trigger_monsterjump =
 //////////////////////////////////////////////////////////////////////////////
 // end dumptruck_ds additions //////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
- 
-/*
-trigger_infight
-
-target = monster that gets mad
-target2 = who target1 will be angry at
-
-spawnflag 1 = mutual hate, both targets get angry at each other instantly
-*/
-
-float INFIGHT_MUTUAL = 1;
-
-void(entity t1, entity t2) make_angry_at =
-{
-	if (t2.health > 0 && t1.health > 0) { // checks if targets are alive
-		if (t1.enemy.classname == "player")
-			t1.oldenemy = t1.enemy;
-		t1.enemy = t2;
-
-		entity oself = self;
-		self = t1; // FoundTarget() only acts on self
-		FoundTarget();
-		self = oself;
-	}
-};
-
-void() trigger_infight_use = 
-{
-	local entity	t1, t2;
-
-	t1 = find(world, targetname, self.target);
-	t2 = find(world, targetname, self.target2);
-	
-	if (!t1)
-	{
-		dprint("[trigger_infight] Cannot find target\n");
-		return;
-	}
-	if (!t2)
-	{
-		dprint("[trigger_infight] Cannot find target2\n");
-		return;
-	}
-	
-	make_angry_at(t1, t2);
-	
-	if (self.spawnflags & INFIGHT_MUTUAL)
-		make_angry_at(t2, t1);
-};
-
-void() trigger_infight = 
-{
-	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
-		return;
-	
-	self.use = trigger_infight_use;
-};
-
-
 
 //This is necros' trigger_void from Lost Chapters pack, modified by dumptruck_ds
 

--- a/triggers.qc
+++ b/triggers.qc
@@ -1015,6 +1015,65 @@ void() trigger_monsterjump =
 //////////////////////////////////////////////////////////////////////////////
 // end dumptruck_ds additions //////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
+ 
+/*
+trigger_infight
+
+target = monster that gets mad
+target2 = who target1 will be angry at
+
+spawnflag 1 = mutual hate, both targets get angry at each other instantly
+*/
+
+float INFIGHT_MUTUAL = 1;
+
+void(entity t1, entity t2) make_angry_at =
+{
+	if (t2.health > 0 && t1.health > 0) { // checks if targets are alive
+		if (t1.enemy.classname == "player")
+			t1.oldenemy = t1.enemy;
+		t1.enemy = t2;
+
+		entity oself = self;
+		self = t1; // FoundTarget() only acts on self
+		FoundTarget();
+		self = oself;
+	}
+};
+
+void() trigger_infight_use = 
+{
+	local entity	t1, t2;
+
+	t1 = find(world, targetname, self.target);
+	t2 = find(world, targetname, self.target2);
+	
+	if (!t1)
+	{
+		dprint("[trigger_infight] Cannot find target\n");
+		return;
+	}
+	if (!t2)
+	{
+		dprint("[trigger_infight] Cannot find target2\n");
+		return;
+	}
+	
+	make_angry_at(t1, t2);
+	
+	if (self.spawnflags & INFIGHT_MUTUAL)
+		make_angry_at(t2, t1);
+};
+
+void() trigger_infight = 
+{
+	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
+		return;
+	
+	self.use = trigger_infight_use;
+};
+
+
 
 //This is necros' trigger_void from Lost Chapters pack, modified by dumptruck_ds
 


### PR DESCRIPTION
Some custom features that I used on the map Mountains of Insanity. The progs.dat released originally with the map was based on progs_dump 2.0RC1, so I rebased it into the release version 2.0, and refactored/cleaned up a few hacky parts.

- func_door now has built-in switchable shadows support. Simply setting _switchableshadow to 1 makes it work out of the box;
- misc_shadowcontroller is a point entity that controls switchable shadows on any other brush entity that supports it;
- func_shadow is a an invisible, non-clipping brush entity used only to cast shadows (including switchable ones, controllable with misc_shadowcontroller);
- func_togglevisiblewall is a func_wall that can be toggled visible/invisible (together with switchable shadows if enabled);
- misc_infight provokes an infight between targeted monsters.
- misc_model can be affected by gravity, made solid, and have a custom bounding box. 