### PR TITLE
Fix classname check in Enforcer's LaunchLaser

### DIFF
--- a/enforcer.qc
+++ b/enforcer.qc
@@ -74,7 +74,7 @@ void() Laser_Touch =
 void(vector org, vector vec) LaunchLaser =
 {
 
-	if (self.classname == "monster_enforcer" || "monster_army")
+	if (self.classname == "monster_enforcer" || self.classname == "monster_army")
 		sound_attack (self, CHAN_WEAPON, "enforcer/enfire.wav", 1, ATTN_NORM);
 
 	vec = normalize(vec);


### PR DESCRIPTION
Fixes a buggy if statement in the `LaunchLaser` function in `enforcer.qc`, as reported by a compiler warning in FTEQCC. The if statement always resolves to true, because even if the comparison fails the constant `"monster_army"` is always implicitly coerced to true.

Truth be told, I don't understand what is the purpose of the if statement: when can `LaunchLaser` ever be executed if the classname is something other than `monster_enforcer`? Regardless, the code should now at least work how it was intended to work. 😄 