### PR TITLE
Alkaline features

### DIFF
--- a/buttons.qc
+++ b/buttons.qc
@@ -68,6 +68,58 @@ void() button_killed =
 };
 
 
+
+// adapted from Copper, thanks Lunaran
+void(entity b) button_lock =
+{
+	entity oself;
+
+	if (b.estate == STATE_INACTIVE)
+		return;
+
+	oself = self;
+	self = b;
+
+	if (self.state == STATE_UP || self.state == STATE_TOP)
+		self.prevstate = STATE_TOP;
+	else 
+		self.prevstate = STATE_BOTTOM;
+
+	if (self.max_health)
+		self.takedamage = DAMAGE_NO;
+	self.state = STATE_UP;
+	SUB_CalcMove (self.pos2, self.speed, button_wait);
+	self.estate = STATE_INACTIVE;
+
+	self = oself;
+}
+void(entity b, float dontresetstate) button_unlock =
+{
+	entity oself;
+
+	if (b.estate == STATE_ACTIVE)
+		return;
+
+	oself = self;
+	self = b;
+
+	if (!dontresetstate || self.wait != -1 || self.prevstate == STATE_BOTTOM) {
+		if (self.max_health)
+		{
+			self.takedamage = DAMAGE_YES;
+			self.health = self.max_health;
+		}
+		self.frame = 0;			// use normal textures
+		self.state = STATE_DOWN;
+		SUB_CalcMove (self.pos1, self.speed, button_done);
+	}
+
+	self.estate = STATE_ACTIVE;
+
+	self = oself;
+}
+
+
 /*QUAKED func_button (0 .5 .8) ? X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 When a button is touched, it moves some distance in the direction of it's angle, triggers all of it's targets, waits some time, then returns to it's original position where it can be triggered again.
 

--- a/client.qc
+++ b/client.qc
@@ -301,7 +301,10 @@ void() execute_changelevel =
 		other.movetype = MOVETYPE_NONE;
 		other.modelindex = 0;
 		setorigin (other, pos.origin);
+		fog_setFromEnt(other, pos);
+		
 		other = find (other, classname, "player");
+
 	}
 	// Drake -- dumptruck_ds
 	if (cutscene)
@@ -604,6 +607,20 @@ void() PutClientInServer =
 	self.origin = spot.origin + '0 0 1';
 	self.angles = spot.angles;
 	self.fixangle = TRUE;		// turn this way immediately
+
+	// fog control.
+	// Looks if there's any fog values set at the current spawn point. If not, looks for those in worldspawn instead
+	if (spot.fog_density)
+		fog_save(self, spot.fog_density, spot.fog_color);
+	else if (world.fog_density)
+		fog_save(self, world.fog_density, world.fog_color);
+
+	if (spot.skyfog_density)
+		skyfog_save(self, spot.skyfog_density);
+	else if (world.skyfog_density)
+		skyfog_save(self, world.skyfog_density);
+
+	cleanUpClientStuff = 2; // decreased on subsequent frames, used to startup some fog-related stuff
 
 // oh, this is a hack!
 	setmodel (self, "progs/eyes.mdl");
@@ -1085,6 +1102,10 @@ void() PlayerPreThink =
 		do_ladder_physics = FALSE;
 		self.gravity = self.wantedgravity;
 	}
+
+	// If just spawned in, try to recover previous fog values from own client entity, if any
+	if (cleanUpClientStuff)
+		fog_setFromEnt(self, self); 
 
 	makevectors (self.v_angle);		// is this still used
 

--- a/defs.qc
+++ b/defs.qc
@@ -927,3 +927,22 @@ float HEAL_MONSTER_ONLY	= 4;
 .float shardvalue; // ammo shard value
 
 .float drop_item; // key DropStuff
+
+
+//
+// fog
+//
+.vector		fog_color, fog_color2;
+.float		fog_density, fog_density2;
+.float 		skyfog_density, skyfog_density2;
+.entity 	fogblend_entity;
+.float 		distance;
+
+void( entity client, float density, vector color ) fog_save;
+void( entity client, float density) skyfog_save;
+void( entity client, entity fogger ) fog_setFromEnt;
+void( entity client, float density, vector color ) fog_set;
+void( entity client, float density) skyfog_set;
+
+nosave float cleanUpClientStuff;
+nosave float gamestarted;

--- a/defs.qc
+++ b/defs.qc
@@ -929,6 +929,17 @@ float HEAL_MONSTER_ONLY	= 4;
 .float drop_item; // key DropStuff
 
 
+
+float TRIGGER_CENTERPRINTALL = 1048576;
+
+// entity state
+.float estate;
+.void() dormant_use;
+float STATE_ACTIVE      = 0;
+float STATE_INACTIVE    = 1;
+
+.float prevstate;
+
 //
 // fog
 //

--- a/doors.qc
+++ b/doors.qc
@@ -281,6 +281,76 @@ void() door_touch =
 	keylock_try_to_unlock (other, "", door_unlock);
 };
 
+
+
+/*
+=============================================================================
+ENTITY STATE FUNCTIONS
+=============================================================================
+*/
+
+void(entity e, float closealldoors) door_estate_lock = {
+	local entity oself, next;
+
+	if (e.owner.estate == STATE_INACTIVE) return;
+
+	oself = self;
+	self = e.owner;
+
+	self.estate = STATE_INACTIVE;
+
+	self.prevstate = self.state;
+
+	if (self.state == STATE_UP || self.state == STATE_TOP) {
+		if (
+			!(self.wait == -1 || (self.spawnflags & DOOR_TOGGLE))
+			|| closealldoors
+		) door_go_down();
+	}
+
+	if (self.max_health) {
+		next = self;
+		do {
+			//e.health = 0;
+			next.takedamage = DAMAGE_NO;
+			next = next.enemy;
+		} while ( (next != self) && (next != world) );
+	}
+
+	self = oself;
+
+}
+
+void(entity e, float openalldoors) door_estate_unlock = {
+	local entity oself, next;
+	
+	if (e.owner.estate == STATE_ACTIVE) return;
+
+	oself = self;
+	self = e.owner;
+
+	if (self.prevstate == STATE_UP || self.prevstate == STATE_TOP) {
+		if (
+			(self.wait == -1 || (self.spawnflags & DOOR_TOGGLE))
+			&& openalldoors
+		) door_go_up();
+	}
+
+	if (self.max_health) {
+		next = self;
+		do {
+			next.health = next.max_health;
+			next.takedamage = DAMAGE_YES;
+			next = next.enemy;
+		} while ( (next != self) && (next != world) );
+	}
+
+	self.estate = STATE_ACTIVE;
+
+	self = oself;
+}
+
+
 /*
 =============================================================================
 

--- a/dtmisc.qc
+++ b/dtmisc.qc
@@ -1045,6 +1045,8 @@ void() misc_particle_stream =
 
 void() heal_touch =
 {
+  if (self.estate != STATE_ACTIVE)
+    return;
   if (other.movetype == MOVETYPE_NOCLIP) // from Copper -- dumptruck_ds
     return FALSE;
 	if(self.spawnflags & HEAL_PLAYER_ONLY && other.classname != "player")
@@ -1130,4 +1132,6 @@ void() trigger_heal =
 	}
 	else
 		self.touch = heal_touch;
+
+  SUB_CheckWaiting();
 };

--- a/fgd_def/pd_201_JACK.fgd
+++ b/fgd_def/pd_201_JACK.fgd
@@ -52,6 +52,7 @@
 	fog_density(string) : "Fog Density example = (0.05)"
 	fog_color(string) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
 	sky(string) : "Sky Texture" :  : "Must have compatible skybox textures in gfx/env folder."
+	skyfog_density(float) : "Skyfog Density" : "0.5" : "How much fog is applied to skybrushes (def 0.5). Set to -1 to disable."
 ]
 
 //
@@ -164,12 +165,27 @@ state(choices) =
 @baseclass = OneTarget[target(target_destination) : "Target"]
 
 
+@baseclass = Fog [ 
+	fog_density(string) : "Fog Density" : : "Set to -1 to disable fog."
+	fog_color(color1) : "Fog Color"
+	skyfog_density(string) : "Skyfog Density": : "Set to -1 to disable skyfog."
+]
+@baseclass = FogShift [ 
+	fog_density(string) : "Start Fog Density"  : : "Set to -1 to disable fog."
+	fog_color(color1) : "Start Fog Color" 
+	skyfog_density(string) : "Start Skyfog Density" : : "Set to -1 to disable skyfog."
+	fog_density2(string) : "End Fog Density" : : "Set to -1 to disable fog."
+	fog_color2(color1) : "End Fog Color" 
+	skyfog_density2(string) : "End Skyfog Density" : : "Set to -1 to disable skyfog."
+]
+    
+
 //
 // player starts, deathmatch, coop, teleport
 //
 
-@baseclass base(Appearflags) flags(Angle) size(-16 -16 -24, 16 16 32) offset(0 0 24) color(0 255 0) = PlayerClass []
-@baseclass base(Appearflags) size(-16 -16 -24, 16 16 32)color(0 255 0) studio("progs/player.mdl") = PlayerClassAlt []
+@baseclass base(Appearflags, Fog) flags(Angle) size(-16 -16 -24, 16 16 32) offset(0 0 24) color(0 255 0) = PlayerClass []
+@baseclass base(Appearflags, Fog) size(-16 -16 -24, 16 16 32)color(0 255 0) studio("progs/player.mdl") = PlayerClassAlt []
 @baseclass base(Appearflags) size(-64 -64 -24, 64 64 32)color(206 18 18) studio("progs/teleport.mdl") = MonsterClass []
 
 //____TW_EDIT____
@@ -1920,6 +1936,58 @@ spawnflags(Flags) =
 			4 : "target4"
 		]
 ]
+
+
+///////////////////////////////////////////////////////////
+//                     Fog triggers                      //
+///////////////////////////////////////////////////////////
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fogblend : 
+"Trigger: Fog Blend
+Acts as a smoothly blending portal between two zones of different fog. Sets the fog for any client passing through it, blending their global fog settings between start and end values proportional to their position within the trigger.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	distance(integer) : "Length of blend distance (defaults to size of trigger)"
+	angle(integer) : "Axis of motion of blend (points toward end values)"
+]
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fog : 
+"Trigger: Sets a fog.
+Smoothly blends client's currently applied fog to this value over time.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	fog_density(string) : "Fog Density" 
+	fog_color(color1) : "Fog Color"
+	speed(string) : "Time to blend (-1 for instant)"
+	delay(string) : "Pause before starting blend"
+]
+
+@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend : 
+"Target: Fog Blend
+Activator's fog will toggle between fog_color/fog_density and fog_color2/fog_density2 values, smoothly blending it over time.
+If you check the 'one-way' spawnflag, it'll only blend over to fog_color2/fog_density2 - unless you check the 'reverse' flag as well, which will make it blend only to fog_color/fog_density.
+Checking 'All clients' will affect all connected players.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make this take too long
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	spawnflags(flags) = [
+		1 : "One-Way Only" : 0
+		2 : "Reverse Start/End" : 0
+		4 : "All clients" : 0
+	]
+	delay(string) : "Pause before starting blend"
+	speed(string) : "Time to blend (-1 for instant)"
+	speed2(string) : "Time to blend back, if different (-1 for instant)"
+]
+
 
 ///////////////////////////////////////////////////////////
 //dumptruck�s additions via Joshua Skelton�s Quake Tools///

--- a/fgd_def/pd_201_JACK.fgd
+++ b/fgd_def/pd_201_JACK.fgd
@@ -178,7 +178,18 @@ state(choices) =
 	fog_color2(color1) : "End Fog Color" 
 	skyfog_density2(string) : "End Skyfog Density" : : "Set to -1 to disable skyfog."
 ]
-    
+ 
+
+
+@baseclass = TriggerWait [
+	is_waiting(choices) : "Dormant Trigger" : 0 :
+	"If set to 1, the trigger starts dormant and waits for activation. Subsequent activations trigger its target as usual." =
+	[
+		0 : "Default"
+		1 : "Wait for Trigger"
+	]
+]
+
 
 //
 // player starts, deathmatch, coop, teleport
@@ -1334,11 +1345,11 @@ _color(color255) : "Light color"
 ]
 
 //____TW_EDIT____
-@SolidClass base(Appearflags) = trigger_ladder : "Invisible ladder entity. When player is touching this entity, they can climb by pressing jump."
+@SolidClass base(Appearflags, TriggerWait) = trigger_ladder : "Invisible ladder entity. When player is touching this entity, they can climb by pressing jump."
 [
 	angle(integer) : "the direction player must be facing to climb ladder"
 ]
-@SolidClass base(Appearflags) = trigger_void : "Use this for a 'void' area. Removes monsters, gibs, ammo, etc... also kills player"
+@SolidClass base(Appearflags, TriggerWait) = trigger_void : "Use this for a 'void' area. Removes monsters, gibs, ammo, etc... also kills player"
 [
 spawnflags(Flags) =
 [
@@ -1761,7 +1772,7 @@ spawnflags(Flags) =
 // triggers
 //
 
-@baseclass base(Appearflags, Target, Targetname) = Trigger
+@baseclass base(Appearflags, Target, Targetname, TriggerWait) = Trigger
 [
 	sounds(choices) : "Sound style" : 0 =
 	[
@@ -1774,7 +1785,7 @@ spawnflags(Flags) =
 	message(string) : "Message"
 ]
 
-@SolidClass base(OneTarget, OneTargetname, Appearflags) = trigger_changelevel : "Trigger: Change level"
+@SolidClass base(OneTarget, OneTargetname, Appearflags, TriggerWait) = trigger_changelevel : "Trigger: Change level"
 [
 	map(string) : "Next map"
 	//target(target_destination) : "Target"
@@ -1805,7 +1816,7 @@ spawnflags(Flags) =
 
 //dumptruck_ds added from Hipnotic Mission Pack
 //____TW_EDIT____
-@SolidClass base(Appearflags, Target, Targetname) = trigger_usekey : "Trigger: Requires a Key. NOTE: You must specify either the silver or gold key by setting the relevant spawnflag, or specify an item_key_custom by setting the 'keyname' value so that it matches the 'keyname' value of the item_key_custom."
+@SolidClass base(Appearflags, Target, Targetname, TriggerWait) = trigger_usekey : "Trigger: Requires a Key. NOTE: You must specify either the silver or gold key by setting the relevant spawnflag, or specify an item_key_custom by setting the 'keyname' value so that it matches the 'keyname' value of the item_key_custom."
 [
 	cnt(choices) : "Leave key in player's inventory?" : 0 =
 	[
@@ -1838,7 +1849,7 @@ spawnflags(Flags) =
 			1 : "Wait for Trigger"
 		]
 	]
-@SolidClass base(OneTarget, OneTargetname) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
+@SolidClass base(OneTarget, OneTargetname, TriggerWait) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
 	[
 		spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 	]
@@ -1848,7 +1859,7 @@ spawnflags(Flags) =
 	wait(integer) : "Delay before reset" : 10
 ]
 //____TW_EDIT____
-@SolidClass base(Appearflags, OneTarget, Targetname) = trigger_teleport : "Trigger Teleporter - Any object touching this will be transported to the corresponding 'info_teleport_destination' entity. Or if RANDOM is chosen, 'info_teleport_random' entities will be used. NOTE - To have a dormant 'trigger_teleport' (will not teleport until unlocked), set 'is_waiting' to 1 and use 'targetname2' on the 'trigger_teleport'. Target this 'targetname2' with another trigger entity to unlock it. If the 'trigger_teleport' has a 'targetname', it will only teleport entities when it has been fired. NOTE - This is not compatible with 'is_waiting'. SILENT'(2) eliminates the teleporter ambient noise (good for hidden monster teleporters. RANDOM(4) causes the teleporter to send the traveller to a random destination among the 'info_teleport_random' markers in the level.  You MUST place a count field that is the number of 'info_teleport_random' entities you placed. STEALTH(8) eliminates the particle flash and noise when an entity is teleported. MONSTER_ONLY(16) will only teleport monsters."
+@SolidClass base(Appearflags, OneTarget, Targetname, TriggerWait) = trigger_teleport : "Trigger Teleporter - Any object touching this will be transported to the corresponding 'info_teleport_destination' entity. Or if RANDOM is chosen, 'info_teleport_random' entities will be used. NOTE - To have a dormant 'trigger_teleport' (will not teleport until unlocked), set 'is_waiting' to 1 and use 'targetname2' on the 'trigger_teleport'. Target this 'targetname2' with another trigger entity to unlock it. If the 'trigger_teleport' has a 'targetname', it will only teleport entities when it has been fired. NOTE - This is not compatible with 'is_waiting'. SILENT'(2) eliminates the teleporter ambient noise (good for hidden monster teleporters. RANDOM(4) causes the teleporter to send the traveller to a random destination among the 'info_teleport_random' markers in the level.  You MUST place a count field that is the number of 'info_teleport_random' entities you placed. STEALTH(8) eliminates the particle flash and noise when an entity is teleported. MONSTER_ONLY(16) will only teleport monsters."
 [
 	spawnflags(Flags) =
 	[
@@ -1879,10 +1890,10 @@ spawnflags(Flags) =
 ]
 
 //____TW_EDIT____
-@SolidClass base(Appearflags) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at 'info_player_start' for an axe only spawn. Make sure and add a 'weapon_shotgun' to your map!"
+@SolidClass base(Appearflags, TriggerWait) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at 'info_player_start' for an axe only spawn. Make sure and add a 'weapon_shotgun' to your map!"
 []
 @PointClass base(Targetname, Trigger) = trigger_relay : "Trigger relay" []
-@SolidClass base(Angle, Appearflags, OneTargetname) = trigger_monsterjump : "Trigger: Monster jump"
+@SolidClass base(Angle, Appearflags, OneTargetname, TriggerWait) = trigger_monsterjump : "Trigger: Monster jump"
 [
 	speed(integer) : "Jump Speed" : 200
 	height(integer) : "Jump Height" : 200
@@ -1895,14 +1906,14 @@ spawnflags(Flags) =
 	delay (integer) : "Delay"
 	message(string) : "Message"
 ]
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push : "Trigger: Push"
+@SolidClass base(Angle, Appearflags, Targetnam, TriggerWaite) = trigger_push : "Trigger: Push"
 [
 	spawnflags(flags) = [ 1: "Push once" : 0 ]
 	speed(integer) : "Speed" : 1000
 ]
 
 //____TW_EDIT____
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent. NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds should not be looped."
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent. NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds should not be looped."
 [
 	spawnflags(flags) =
 			[
@@ -1914,7 +1925,7 @@ spawnflags(Flags) =
 	speed(integer) : "Speed" : 1000
 	noise(string) : "Custom Sound"
 ]
-@SolidClass  base(Appearflags, OneTargetname) = trigger_hurt : "Trigger: Hurt"
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_hurt : "Trigger: Hurt"
 [
 	dmg(integer) : "Damage per second" : 5
 ]
@@ -2353,7 +2364,7 @@ noise(string) : "Path to custom sound"
 	noise1(string) : "Sound Upon Deactivation"
 ]
 
-@SolidClass base(Appearflags) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
+@SolidClass base(Appearflags, TriggerWait) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
 [
 sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to play from within music folder"
 ]
@@ -2364,7 +2375,7 @@ sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to pla
 // @SolidClass base(Appearflags,Trigger) = trigger_look : "Trigger: On look at first target"
 // [
 // ]
-@SolidClass base(Appearflags, Trigger, Target) = trigger_look : "Trigger: Trigger something when a player enters this volume and looks directly at a targeted brush entity. Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple"
+@SolidClass base(Appearflags, Trigger, Target, TriggerWait) = trigger_look : "Trigger: Trigger something when a player enters this volume and looks directly at a targeted brush entity. Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple"
 [
 	speed(integer) : "Distance from player to search for trigger, adjust if the target is too far from the trigger" : 500
 	wait(integer) : "Time between re-triggering"
@@ -2478,7 +2489,7 @@ spawnflags(flags) =
 	]
 ]
 //____TW_EDIT____
-@SolidClass  base(Appearflags, OneTargetname) = trigger_heal : "Trigger: Heal - Any object touching this will be healed. 'heal_amount ' - the amount to heal each time (default 5). 'wait ' - the time between each healing (default 1). 'health_max' - the upper limit for the healing (default 100, max 250). 'noise' - path to custom sound file."
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_heal : "Trigger: Heal - Any object touching this will be healed. 'heal_amount ' - the amount to heal each time (default 5). 'wait ' - the time between each healing (default 1). 'health_max' - the upper limit for the healing (default 100, max 250). 'noise' - path to custom sound file."
 [
 	wait(integer) : "Time between each healing (default 1)" : 1
 	heal_amount(integer) : "Healing per second" : 5

--- a/fgd_def/pd_201_JACK.fgd
+++ b/fgd_def/pd_201_JACK.fgd
@@ -191,6 +191,12 @@ state(choices) =
 ]
 
 
+@baseclass = Message [
+	spawnflags(flags) = [
+		1048576 : "Message all players" : 0
+	]
+]
+
 //
 // player starts, deathmatch, coop, teleport
 //
@@ -1647,7 +1653,7 @@ dmg(integer) : "Damage" : 100
 	noise(string) : "Path of sound when triggered"
 ]
 
-@SolidClass base(Angle, Appearflags, Targetname, Target) = func_button : "Button" //modified by dumptruck_ds to add Target
+@SolidClass base(Angle, Appearflags, Targetname, Target, Message) = func_button : "Button" //modified by dumptruck_ds to add Target
 [
 	speed(integer) : "Speed" : 40
 	lip(integer) : "Lip" : 4
@@ -1772,7 +1778,7 @@ spawnflags(Flags) =
 // triggers
 //
 
-@baseclass base(Appearflags, Target, Targetname, TriggerWait) = Trigger
+@baseclass base(Appearflags, Target, Targetname, TriggerWait, Message) = Trigger
 [
 	sounds(choices) : "Sound style" : 0 =
 	[

--- a/fgd_def/pd_201_TB.fgd
+++ b/fgd_def/pd_201_TB.fgd
@@ -198,6 +198,15 @@ state(choices) =
 
 @baseclass = OneTarget[target(target_destination) : "Target"]
 
+@baseclass = TriggerWait [
+	is_waiting(choices) : "Dormant Trigger" : 0 :
+	"If set to 1, the trigger starts dormant and waits for activation. Subsequent activations trigger its target as usual." =
+	[
+		0 : "Default"
+		1 : "Wait for Trigger"
+	]
+]
+
 //////////////////////
 // end dumptruck_ds //
 //////////////////////
@@ -296,7 +305,7 @@ NOTE when a trigger_teleport has a targetname it must be triggered to operate, s
 	noise(string) : "noise"
 	touch(string) : "self.touch"
 ]
-@PointClass base(Appearflags) = info_intermission : "Intermission camera"
+@PointClass base(Appearflags, Fog) = info_intermission : "Intermission camera"
 [
 	mangle(string) : "Camera angle (Pitch Yaw Roll)"
 ]
@@ -1467,14 +1476,14 @@ Default is 0.3 seconds.
 	weapon(float) : "Duration of each strike" : "0.3"
 ]
 
-@SolidClass base(Appearflags) = trigger_ladder : "Invisible ladder entity.
+@SolidClass base(Appearflags, TriggerWait) = trigger_ladder : "Invisible ladder entity.
 
 When player is touching this entity, she can climb by pushing jump."
 [
 	angle(integer) : "the direction player must be facing to climb ladder"
 ]
 
-@SolidClass base(Appearflags) = trigger_void : "Use this for a 'void' area. Removes monsters, gibs, ammo, etc... also kills player"
+@SolidClass base(Appearflags, TriggerWait) = trigger_void : "Use this for a 'void' area. Removes monsters, gibs, ammo, etc... also kills player"
 
 [
 spawnflags(Flags) =
@@ -1891,7 +1900,7 @@ spawnflags(Flags) =
 // triggers
 //
 
-@baseclass base(Appearflags, Target, Targetname) = Trigger
+@baseclass base(Appearflags, Target, Targetname, TriggerWait) = Trigger
 [
 	sounds(choices) : "Sound style" : 0 =
 	[
@@ -1904,7 +1913,7 @@ spawnflags(Flags) =
 	message(string) : "Message"
 ]
 
-@SolidClass base(OneTarget, OneTargetname, Appearflags) = trigger_changelevel : "Trigger: Change level"
+@SolidClass base(OneTarget, OneTargetname, Appearflags, TriggerWait) = trigger_changelevel : "Trigger: Change level"
 [
 	map(string) : "Next map"
 	//target(target_destination) : "Target"
@@ -1927,7 +1936,7 @@ spawnflags(Flags) =
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
 
-@SolidClass base(Appearflags) = trigger_setgravity : "Trigger: sets the gravity of a player or monsters
+@SolidClass base(Appearflags, TriggerWait) = trigger_setgravity : "Trigger: sets the gravity of a player or monsters
 
 gravity = what to set the players gravity to
 
@@ -1949,7 +1958,7 @@ If using multiple triggers, do not have them touching. Leave a 'buffer' between 
 ]
 
 //dumptruck_ds added from Hipnotic Mission Pack
-@SolidClass base(Appearflags, Target, Targetname) = trigger_usekey :
+@SolidClass base(Appearflags, Target, Targetname, TriggerWait) = trigger_usekey :
 "Trigger: Requires a Key
 
 NOTE: You must specify either the silver or gold key by setting the relevant spawnflag, or specify an item_key_custom by setting the 'keyname' value so that it matches the 'keyname' value of the item_key_custom."
@@ -1985,11 +1994,11 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 		1 : "Wait for Trigger"
 	]
 ]
-@SolidClass base(OneTarget, OneTargetname) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
+@SolidClass base(OneTarget, OneTargetname, TriggerWait) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
 [
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
-@SolidClass base(Trigger, OneTargetname) = trigger_secret : "Trigger: Secret"
+@SolidClass base(Trigger, OneTargetname, TriggerWait) = trigger_secret : "Trigger: Secret"
 [
 	sounds(choices) : "Sound" : 1 =
 	[
@@ -1999,7 +2008,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
 
-@SolidClass base(Appearflags, OneTarget, Targetname) = trigger_teleport : "Trigger: Teleporter
+@SolidClass base(Appearflags, OneTarget, Targetname, TriggerWait) = trigger_teleport : "Trigger: Teleporter
 
 Any object touching this will be transported to the corresponding
 info_teleport_destination entity. Or if RANDOM is chosen, info_teleport_random
@@ -2038,7 +2047,7 @@ MONSTER_ONLY(16) will only teleport monsters"
 	]
 ]
 
-@SolidClass base(Appearflags) = trigger_setskill : "Trigger: Set skill"
+@SolidClass base(Appearflags, TriggerWait) = trigger_setskill : "Trigger: Set skill"
 [
 	message(choices) : "Skill to change to" : 1 =
 	[
@@ -2051,11 +2060,11 @@ MONSTER_ONLY(16) will only teleport monsters"
 @PointClass base(Trigger) = trigger_relay : "Trigger: Relay"
 [
 ]
-@SolidClass base(Appearflags) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at info_player_start for an axe only spawn.
+@SolidClass base(Appearflags, TriggerWait) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at info_player_start for an axe only spawn.
 
 Make sure and add a weapon_shotgun to your map!"
 []
-@SolidClass base(Angle, Appearflags, OneTargetname) = trigger_monsterjump : "Trigger: Monster jump"
+@SolidClass base(Angle, Appearflags, OneTargetname, TriggerWait) = trigger_monsterjump : "Trigger: Monster jump"
 [
 	speed(integer) : "Jump Speed" : 200
 	height(integer) : "Jump Height" : 200
@@ -2068,12 +2077,12 @@ Make sure and add a weapon_shotgun to your map!"
 	delay (integer) : "Delay"
 	message(string) : "Message"
 ]
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push : "Trigger: Push"
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [
 	spawnflags(flags) = [ 1: "Push once" : 0 ]
 	speed(integer) : "Speed" : 1000
 ]
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent.
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent.
 
 NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds should not be looped."
 [
@@ -2087,7 +2096,7 @@ NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds sho
 	speed(integer) : "Speed" : 1000
 	noise(string) : "Custom Sound"
 ]
-@SolidClass  base(Appearflags, OneTargetname) = trigger_hurt : "Trigger: Hurt"
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_hurt : "Trigger: Hurt"
 [
 	dmg(integer) : "Damage per second" : 5
 ]
@@ -2750,7 +2759,7 @@ delay how much time to wait before firing after being switched on."
 		]
 	]
 
-@SolidClass base(Appearflags) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
+@SolidClass base(Appearflags, TriggerWait) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
 [
 sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to play from within music folder"
 ]
@@ -2841,7 +2850,7 @@ spawnflags(flags) =
 	]
 ]
 
-@SolidClass  base(Appearflags, OneTargetname) = trigger_heal : "Trigger: Heal
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_heal : "Trigger: Heal
 Any object touching this will be healed
 heal_amount -- the amount to heal each time (default 5)
 wait -- the time between each healing (default 1)

--- a/fgd_def/pd_201_TB.fgd
+++ b/fgd_def/pd_201_TB.fgd
@@ -84,7 +84,8 @@
 	_gamma(integer) : "Lightmap gamma" : 1 : "Adjust brightness of final lightmap. Default 1, >1 is brighter, <1 is darker"
 	fog(string) : "Fog Command" :  : "ENGINE only 'console command' for setting fog parameters, Density/R/G/B example = (0.05 0.3 0.3 0.3)."
 	fog_density(string) : "Fog Density example = (0.05)"
-	fog_color(string) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
+	fog_color(color1) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
+	skyfog_density(float) : "Skyfog Density" : "0.5" : "How much fog is applied to skybrushes (def 0.5). Set to -1 to disable."
 	sky(string) : "Sky Texture" :  : "Must have compatible skybox textures in gfx/env folder."
 ]
 
@@ -201,13 +202,29 @@ state(choices) =
 // end dumptruck_ds //
 //////////////////////
 
+
+@baseclass = Fog [ 
+	fog_density(string) : "Fog Density" : : "Set to -1 to disable fog."
+	fog_color(color1) : "Fog Color"
+	skyfog_density(string) : "Skyfog Density": : "Set to -1 to disable skyfog."
+]
+@baseclass = FogShift [ 
+	fog_density(string) : "Start Fog Density"  : : "Set to -1 to disable fog."
+	fog_color(color1) : "Start Fog Color" 
+	skyfog_density(string) : "Start Skyfog Density" : : "Set to -1 to disable skyfog."
+	fog_density2(string) : "End Fog Density" : : "Set to -1 to disable fog."
+	fog_color2(color1) : "End Fog Color" 
+	skyfog_density2(string) : "End Skyfog Density" : : "Set to -1 to disable skyfog."
+]
+
+
 //
 // player starts, deathmatch, coop, teleport
 //
 
-@baseclass base(Appearflags) size(-16 -16 -24, 16 16 32)
+@baseclass base(Appearflags, Fog) size(-16 -16 -24, 16 16 32)
 	color(0 255 0) model({ "path": ":progs/player.mdl" }) = PlayerClass []
-@baseclass base(Appearflags) size(-16 -16 -24, 16 16 32)
+@baseclass base(Appearflags, Fog) size(-16 -16 -24, 16 16 32)
 	color(0 255 0) model({ "path": ":progs/player.mdl" , "frame": 120}) = PlayerClassAlt []
 @baseclass base(Appearflags) size(-64 -64 -24, 64 64 32)
 // @baseclass base(Appearflags) size(-32 -32 -24, 32 32 64)
@@ -2086,6 +2103,7 @@ If you want to make them angry at each other instantly, you can set the spawnfla
 	target(target_destination) : "The monster who will get angry."
 	target2(target_destination) : "Who target will get angry at."
 	spawnflags(flags) = [ 1: "Mutual hate" : 0 ]
+]
 
 @PointClass base(Appearflags, Targetname) = trigger_changetarget : "Changes the target field on an entity.
 
@@ -2102,6 +2120,57 @@ If you want to make them angry at each other instantly, you can set the spawnfla
 			4 : "target4"
 		]
 ]
+
+///////////////////////////////////////////////////////////
+//                     Fog triggers                      //
+///////////////////////////////////////////////////////////
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fogblend : 
+"Trigger: Fog Blend
+Acts as a smoothly blending portal between two zones of different fog. Sets the fog for any client passing through it, blending their global fog settings between start and end values proportional to their position within the trigger.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	distance(integer) : "Length of blend distance (defaults to size of trigger)"
+	angle(integer) : "Axis of motion of blend (points toward end values)"
+]
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fog : 
+"Trigger: Sets a fog.
+Smoothly blends client's currently applied fog to this value over time.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	fog_density(string) : "Fog Density" 
+	fog_color(color1) : "Fog Color"
+	speed(string) : "Time to blend (-1 for instant)"
+	delay(string) : "Pause before starting blend"
+]
+
+@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend : 
+"Target: Fog Blend
+Activator's fog will toggle between fog_color/fog_density and fog_color2/fog_density2 values, smoothly blending it over time.
+If you check the 'one-way' spawnflag, it'll only blend over to fog_color2/fog_density2 - unless you check the 'reverse' flag as well, which will make it blend only to fog_color/fog_density.
+Checking 'All clients' will affect all connected players.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make this take too long
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	spawnflags(flags) = [
+		1 : "One-Way Only" : 0
+		2 : "Reverse Start/End" : 0
+		4 : "All clients" : 0
+	]
+	delay(string) : "Pause before starting blend"
+	speed(string) : "Time to blend (-1 for instant)"
+	speed2(string) : "Time to blend back, if different (-1 for instant)"
+]
+
 
 ///////////////////////////////////////////////////////////
 //dumptruck’s additions via Joshua Skelton’s Quake Tools///

--- a/fgd_def/pd_201_TB.fgd
+++ b/fgd_def/pd_201_TB.fgd
@@ -207,6 +207,12 @@ state(choices) =
 	]
 ]
 
+@baseclass = Message [
+	spawnflags(flags) = [
+		1048576 : "Message all players" : 0
+	]
+]
+
 //////////////////////
 // end dumptruck_ds //
 //////////////////////
@@ -1772,7 +1778,7 @@ NOTE: To have a continuous stream use a func_counter as the target, then set the
 	noise(string) : "Path of sound when triggered"
 ]
 
-@SolidClass base(Angle, Appearflags, Targetname, Target) = func_button : "Button" //modified by dumptruck_ds to add Target
+@SolidClass base(Angle, Appearflags, Targetname, Target, Message) = func_button : "Button" //modified by dumptruck_ds to add Target
 [
 	speed(integer) : "Speed" : 40
 	lip(integer) : "Lip" : 4
@@ -1900,7 +1906,7 @@ spawnflags(Flags) =
 // triggers
 //
 
-@baseclass base(Appearflags, Target, Targetname, TriggerWait) = Trigger
+@baseclass base(Appearflags, Target, Targetname, TriggerWait, Message) = Trigger
 [
 	sounds(choices) : "Sound style" : 0 =
 	[

--- a/fgd_def/pd_201_TB_custom_mdls.fgd
+++ b/fgd_def/pd_201_TB_custom_mdls.fgd
@@ -207,6 +207,11 @@ state(choices) =
 	]
 ]
 
+@baseclass = Message [
+	spawnflags(flags) = [
+		1048576 : "Message all players" : 0
+	]
+]
 //////////////////////
 // end dumptruck_ds //
 //////////////////////
@@ -1761,7 +1766,7 @@ NOTE: To have a continuous stream use a func_counter as the target, then set the
 	noise(string) : "Path of sound when triggered"
 ]
 
-@SolidClass base(Angle, Appearflags, Targetname, Target) = func_button : "Button" //modified by dumptruck_ds to add Target
+@SolidClass base(Angle, Appearflags, Targetname, Target, Message) = func_button : "Button" //modified by dumptruck_ds to add Target
 [
 	speed(integer) : "Speed" : 40
 	lip(integer) : "Lip" : 4
@@ -1888,7 +1893,7 @@ spawnflags(Flags) =
 // triggers
 //
 
-@baseclass base(Appearflags, Target, Targetname) = Trigger
+@baseclass base(Appearflags, Target, Targetname, Message) = Trigger
 [
 	sounds(choices) : "Sound style" : 0 =
 	[

--- a/fgd_def/pd_201_TB_custom_mdls.fgd
+++ b/fgd_def/pd_201_TB_custom_mdls.fgd
@@ -84,7 +84,8 @@
 	_gamma(integer) : "Lightmap gamma" : 1 : "Adjust brightness of final lightmap. Default 1, >1 is brighter, <1 is darker"
 	fog(string) : "Fog Command" :  : "ENGINE only 'console command' for setting fog parameters, Density/R/G/B example = (0.05 0.3 0.3 0.3)."
 	fog_density(string) : "Fog Density example = (0.05)"
-	fog_color(string) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
+	fog_color(color1) : "Fog Color R/G/B example = (0.3 0.3 0.3)"
+	skyfog_density(float) : "Skyfog Density" : "0.5" : "How much fog is applied to skybrushes (def 0.5). Set to -1 to disable."
 	sky(string) : "Sky Texture" :  : "Must have compatible skybox textures in gfx/env folder."
 ]
 
@@ -201,13 +202,28 @@ state(choices) =
 // end dumptruck_ds //
 //////////////////////
 
+
+@baseclass = Fog [ 
+	fog_density(string) : "Fog Density" : : "Set to -1 to disable fog."
+	fog_color(color1) : "Fog Color"
+	skyfog_density(string) : "Skyfog Density": : "Set to -1 to disable skyfog."
+]
+@baseclass = FogShift [ 
+	fog_density(string) : "Start Fog Density"  : : "Set to -1 to disable fog."
+	fog_color(color1) : "Start Fog Color" 
+	skyfog_density(string) : "Start Skyfog Density" : : "Set to -1 to disable skyfog."
+	fog_density2(string) : "End Fog Density" : : "Set to -1 to disable fog."
+	fog_color2(color1) : "End Fog Color" 
+	skyfog_density2(string) : "End Skyfog Density" : : "Set to -1 to disable skyfog."
+]
+
 //
 // player starts, deathmatch, coop, teleport
 //
 
-@baseclass base(Appearflags) size(-16 -16 -24, 16 16 32)
+@baseclass base(Appearflags, Fog) size(-16 -16 -24, 16 16 32)
 	color(0 255 0) model({ "path": ":progs/player.mdl" }) = PlayerClass []
-@baseclass base(Appearflags) size(-16 -16 -24, 16 16 32)
+@baseclass base(Appearflags, Fog) size(-16 -16 -24, 16 16 32)
 	color(0 255 0) model({ "path": ":progs/player.mdl" , "frame": 120}) = PlayerClassAlt []
 @baseclass base(Appearflags) size(-64 -64 -24, 64 64 32)
 color(206 18 18) model({ "path": ":progs/teleport.mdl" }) = MonsterClass []
@@ -2081,6 +2097,58 @@ NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds sho
 			4 : "target4"
 		]
 ]
+
+
+///////////////////////////////////////////////////////////
+//                     Fog triggers                      //
+///////////////////////////////////////////////////////////
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fogblend : 
+"Trigger: Fog Blend
+Acts as a smoothly blending portal between two zones of different fog. Sets the fog for any client passing through it, blending their global fog settings between start and end values proportional to their position within the trigger.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	distance(integer) : "Length of blend distance (defaults to size of trigger)"
+	angle(integer) : "Axis of motion of blend (points toward end values)"
+]
+
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fog : 
+"Trigger: Sets a fog.
+Smoothly blends client's currently applied fog to this value over time.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	fog_density(string) : "Fog Density" 
+	fog_color(color1) : "Fog Color"
+	speed(string) : "Time to blend (-1 for instant)"
+	delay(string) : "Pause before starting blend"
+]
+
+@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend : 
+"Target: Fog Blend
+Activator's fog will toggle between fog_color/fog_density and fog_color2/fog_density2 values, smoothly blending it over time.
+If you check the 'one-way' spawnflag, it'll only blend over to fog_color2/fog_density2 - unless you check the 'reverse' flag as well, which will make it blend only to fog_color/fog_density.
+Checking 'All clients' will affect all connected players.
+
+- both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
+- will 'stuffcmd' 2 dozen times per frame so try not to make this take too long
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	spawnflags(flags) = [
+		1 : "One-Way Only" : 0
+		2 : "Reverse Start/End" : 0
+		4 : "All clients" : 0
+	]
+	delay(string) : "Pause before starting blend"
+	speed(string) : "Time to blend (-1 for instant)"
+	speed2(string) : "Time to blend back, if different (-1 for instant)"
+]
+
 
 ///////////////////////////////////////////////////////////
 //dumptruck’s additions via Joshua Skelton’s Quake Tools///

--- a/fgd_def/pd_201_TB_custom_mdls.fgd
+++ b/fgd_def/pd_201_TB_custom_mdls.fgd
@@ -198,6 +198,15 @@ state(choices) =
 
 @baseclass = OneTarget[target(target_destination) : "Target"]
 
+@baseclass = TriggerWait [
+	is_waiting(choices) : "Dormant Trigger" : 0 :
+	"If set to 1, the trigger starts dormant and waits for activation. Subsequent activations trigger its target as usual." =
+	[
+		0 : "Default"
+		1 : "Wait for Trigger"
+	]
+]
+
 //////////////////////
 // end dumptruck_ds //
 //////////////////////
@@ -294,7 +303,7 @@ NOTE when a trigger_teleport has a targetname it must be triggered to operate, s
 	noise(string) : "noise"
 	touch(string) : "self.touch"
 ]
-@PointClass base(Appearflags) = info_intermission : "Intermission camera"
+@PointClass base(Appearflags, Fog) = info_intermission : "Intermission camera"
 [
 	mangle(string) : "Camera angle (Pitch Yaw Roll)"
 ]
@@ -1892,7 +1901,7 @@ spawnflags(Flags) =
 	message(string) : "Message"
 ]
 
-@SolidClass base(OneTarget, OneTargetname, Appearflags) = trigger_changelevel : "Trigger: Change level"
+@SolidClass base(OneTarget, OneTargetname, Appearflags, TriggerWait) = trigger_changelevel : "Trigger: Change level"
 [
 	map(string) : "Next map"
 	//target(target_destination) : "Target"
@@ -1915,7 +1924,7 @@ spawnflags(Flags) =
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
 
-@SolidClass base(Appearflags) = trigger_setgravity : "Trigger: sets the gravity of a player or monsters
+@SolidClass base(Appearflags, TriggerWait) = trigger_setgravity : "Trigger: sets the gravity of a player or monsters
 
 gravity = what to set the players gravity to
 
@@ -1937,7 +1946,7 @@ If using multiple triggers, do not have them touching. Leave a 'buffer' between 
 ]
 
 //dumptruck_ds added from Hipnotic Mission Pack
-@SolidClass base(Appearflags, Target, Targetname) = trigger_usekey :
+@SolidClass base(Appearflags, Target, Targetname, TriggerWait) = trigger_usekey :
 "Trigger: Requires a Key
 
 NOTE: You must specify either the silver or gold key by setting the relevant spawnflag, or specify an item_key_custom by setting the 'keyname' value so that it matches the 'keyname' value of the item_key_custom."
@@ -1973,7 +1982,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 		1 : "Wait for Trigger"
 	]
 ]
-@SolidClass base(OneTarget, OneTargetname) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
+@SolidClass base(OneTarget, OneTargetname, TriggerWait) = trigger_onlyregistered : "only Triggers only if game is registered (registered == 1)"
 [
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
@@ -1987,7 +1996,7 @@ NOTE: You must specify either the silver or gold key by setting the relevant spa
 	spawnflags(flags) = [ 1: "Not touchable" : 0 ]
 ]
 
-@SolidClass base(Appearflags, OneTarget, Targetname) = trigger_teleport : "Trigger: Teleporter
+@SolidClass base(Appearflags, OneTarget, Targetname, TriggerWait) = trigger_teleport : "Trigger: Teleporter
 
 Any object touching this will be transported to the corresponding
 info_teleport_destination entity. Or if RANDOM is chosen, info_teleport_random
@@ -2026,7 +2035,7 @@ MONSTER_ONLY(16) will only teleport monsters"
 	]
 ]
 
-@SolidClass base(Appearflags) = trigger_setskill : "Trigger: Set skill"
+@SolidClass base(Appearflags, TriggerWait) = trigger_setskill : "Trigger: Set skill"
 [
 	message(choices) : "Skill to change to" : 1 =
 	[
@@ -2039,11 +2048,11 @@ MONSTER_ONLY(16) will only teleport monsters"
 @PointClass base(Trigger) = trigger_relay : "Trigger: Relay"
 [
 ]
-@SolidClass base(Appearflags) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at info_player_start for an axe only spawn.
+@SolidClass base(Appearflags, TriggerWait) = trigger_take_weapon : "Trigger: Remove shotgun on touch. Place at info_player_start for an axe only spawn.
 
 Make sure and add a weapon_shotgun to your map!"
 []
-@SolidClass base(Angle, Appearflags, OneTargetname) = trigger_monsterjump : "Trigger: Monster jump"
+@SolidClass base(Angle, Appearflags, OneTargetname, TriggerWait) = trigger_monsterjump : "Trigger: Monster jump"
 [
 	speed(integer) : "Jump Speed" : 200
 	height(integer) : "Jump Height" : 200
@@ -2056,12 +2065,12 @@ Make sure and add a weapon_shotgun to your map!"
 	delay (integer) : "Delay"
 	message(string) : "Message"
 ]
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push : "Trigger: Push"
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [
 	spawnflags(flags) = [ 1: "Push once" : 0 ]
 	speed(integer) : "Speed" : 1000
 ]
-@SolidClass base(Angle, Appearflags, Targetname) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent.
+@SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push_custom : "Trigger: Push (Custom): Can be toggled on and off, use a custom sound (noise) and be made silent.
 
 NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds should not be looped."
 [
@@ -2075,14 +2084,14 @@ NOTE: Set BOTH Custom Noise spawnflag and the Noise key/value. Custom sounds sho
 	speed(integer) : "Speed" : 1000
 	noise(string) : "Custom Sound"
 ]
-@SolidClass  base(Appearflags, OneTargetname) = trigger_hurt : "Trigger: Hurt"
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_hurt : "Trigger: Hurt"
 [
 	dmg(integer) : "Damage per second" : 5
 ]
 @PointClass size(16 16 16) = misc_noisemaker : "Debug entity: continuously plays enforcer sounds" []
 @PointClass size(16 16 16) = viewthing : "Debug entity: fake player model" []
 
-@PointClass base(Appearflags, Targetname) = trigger_changetarget : "Changes the target field on an entity.
+@PointClass base(Appearflags, Targetname, TriggerWait) = trigger_changetarget : "Changes the target field on an entity.
 
 'message' is the value of the new target.
 
@@ -2722,7 +2731,7 @@ delay how much time to wait before firing after being switched on."
 		]
 	]
 
-@SolidClass base(Appearflags) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
+@SolidClass base(Appearflags, TriggerWait) = trigger_changemusic : "Trigger that changes the currently playing music track. The number of the track to play goes in sounds just like worldspawn."
 [
 sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to play from within music folder"
 ]
@@ -2730,7 +2739,7 @@ sounds(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to pla
 @PointClass base(Appearflags, Targetname) size(-8 -8 -8, 8 8 8) color(200 128 0) = trigger_cdtrack : "Trigger that changes the currently playing music track. The number of the track to play goes in the count key." [
     count(integer) : "Track Number (ex 02->xx)" :  : "CD track or audio file to play from within music folder"
 ]
-@SolidClass base(Appearflags, Trigger, Target) = trigger_look : "Trigger: Trigger something when a player enters this volume and looks directly at a targeted brush entity. Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple"
+@SolidClass base(Appearflags, Trigger, Target, TriggerWait) = trigger_look : "Trigger: Trigger something when a player enters this volume and looks directly at a targeted brush entity. Use the first target key for the looked at item and subsequent targets to trigger events. Add a wait key to make this a trigger_multiple"
 [
 	speed(integer) : "Distance from player to search for trigger, adjust if the target is too far from the trigger" : 500
 	wait(integer) : "Time between re-triggering"
@@ -2821,7 +2830,7 @@ spawnflags(flags) =
 	// ]
 ]
 
-@SolidClass  base(Appearflags, OneTargetname) = trigger_heal : "Trigger: Heal
+@SolidClass  base(Appearflags, OneTargetname, TriggerWait) = trigger_heal : "Trigger: Heal
 Any object touching this will be healed
 heal_amount -- the amount to heal each time (default 5)
 wait -- the time between each healing (default 1)

--- a/fog.qc
+++ b/fog.qc
@@ -1,0 +1,534 @@
+/*
+====================
+
+Fog controllers
+Based on Copper's fog by Lunaran
+Changed by bmFbr
+
+====================
+*/
+
+float FOG_INTERVAL = 0.04166667; // 1/24;
+/*FGD
+@baseclass = Fog [ 
+	fog_density(string) : "Fog Density" 
+	fog_color(string) : "Fog Color" 
+]
+@baseclass = FogShift [ 
+	fog_density(string) : "Start Fog Density" 
+	fog_color(string) : "Start Fog Color" 
+	fog_density2(string) : "End Fog Density" 
+	fog_color2(string) : "End Fog Color" 
+]
+*/
+
+/*
+================
+fog_save
+================
+*/
+void( entity client, float density, vector color ) fog_save =
+{
+	if (client.classname != "player") return;
+	
+	// save whatever we set the client's fog to in case of saves/loads
+	client.fog_density = density;
+	client.fog_color = color;
+}
+
+void( entity client ) fog_save_to_previous =
+{
+	if (client.classname != "player") return;
+	
+	// copies the current fog to the secondary fields to transition from the current fog
+	client.fog_density2 = client.fog_density;
+	client.fog_color2 = client.fog_color;
+}
+
+void( entity client, float density) skyfog_save =
+{
+	if (client.classname != "player") return;
+	
+	client.skyfog_density = density;
+}
+
+void( entity client ) skyfog_save_to_previous =
+{
+	if (client.classname != "player") return;
+	
+	client.skyfog_density2 = client.skyfog_density;
+}
+/*
+================
+fog_setFromEnt
+================
+*/
+void( entity client, entity fogger ) fog_setFromEnt =
+{
+	float density;
+	//
+	// Don't set the fog if the entity has no values, because it might be a custom map with
+	// _fog on the worldspawn instead.
+	// To actually get an entity to clear the fog, density to -1.
+	// The same applies to skyfog
+	
+	//eprint(fogger);
+
+	//dprint3("fog_density: ", ftos(fogger.fog_density*100), "\n");
+	if (fogger.fog_density) {
+		dprint("setting fog\n");
+		density = zeroconvert(fogger.fog_density);
+		fog_set(client, density, fogger.fog_color);
+	}
+	
+	//dprint3("skyfog_density: ", ftos(fogger.skyfog_density*100), "\n");
+	if (fogger.skyfog_density) {
+		dprint("setting skyfog\n");
+		density = zeroconvert(fogger.skyfog_density);
+		skyfog_set(client, density);
+	}
+}
+
+/*
+================
+fog_set
+================
+*/
+void( entity client, float density, vector color) fog_set =
+{
+	if (client.classname != "player") return;
+
+	//dprint9("Setting fog: ", ftos(density), " ", ftos(color_x), " ", ftos(color_y), " ", ftos(color_z), "\n");
+
+	stuffcmd(client, "\nfog ");
+	stuffcmd_float(client, density);
+	stuffcmd(client, " ");
+	stuffcmd_float(client, color_x);
+	stuffcmd(client, " ");
+	stuffcmd_float(client, color_y);
+	stuffcmd(client, " ");
+	stuffcmd_float(client, color_z);
+	stuffcmd(client, "\n");
+
+	fog_save(client, density, color);
+}
+
+
+void( entity client, float density) skyfog_set =
+{
+	if (client.classname != "player") return;
+
+	//dprint3("Setting skyfog: ", ftos(density), "\n");
+
+	stuffcmd(client, "\nr_skyfog ");
+	stuffcmd_float(client, density);
+	stuffcmd(client, "\n");
+
+	skyfog_save(client, density);
+}
+
+/*
+================
+fog_blendTouch
+================
+*/
+void() fog_blendTouch =
+{
+	if (other.classname != "player")
+		return;
+
+	if (other.health <= 0)
+		return;
+	
+	//if (self.estate != STATE_ACTIVE)
+	//	return;
+
+	// fix for only first client getting a fog change when multiple coop clients are touching this at once
+	if (time != self.rad_time)	// because fog is rad
+		if (time < self.attack_finished)
+			return;
+		
+	float f, lerp_density, leaving;
+	float lerp_sdensity;
+	float ent_density, ent_density2, ent_sdensity, ent_sdensity2;
+	vector dorg, mid, ovel;
+	vector lerp_color;
+
+	ent_density = zeroconvert(self.fog_density);
+	ent_density2 = zeroconvert(self.fog_density2);
+
+	ent_sdensity = zeroconvert(self.skyfog_density);
+	ent_sdensity2 = zeroconvert(self.skyfog_density2);
+	
+	// if you run/fall through a fogblend fast enough you can come out the other side 
+	// partially blended, so check if player will exit the trigger bounds before the 
+	// next touch (same class of bug as leaping through lasers in Q2)
+	ovel = other.velocity * FOG_INTERVAL;
+	leaving = ( (other.absmax_x + ovel_x < self.absmin_x) ||
+				(other.absmax_y + ovel_y < self.absmin_y) ||
+				(other.absmax_z + ovel_z < self.absmin_z) ||
+				(other.absmin_x + ovel_x > self.absmax_x) ||
+				(other.absmin_y + ovel_y > self.absmax_y) ||
+				(other.absmin_z + ovel_z > self.absmax_z) );
+	
+	if (leaving)
+	{
+		// last chance to set fog correctly, so snap it to the final values
+		leaving = other.velocity * self.movedir;
+		if (leaving > 0)
+		{
+			lerp_density = ent_density2;
+			lerp_color = self.fog_color2;
+			lerp_sdensity = ent_sdensity2;
+		}
+		else
+		{
+			lerp_density = ent_density;
+			lerp_color = self.fog_color;
+			lerp_sdensity = ent_sdensity;
+		}
+	}
+	else
+	{
+		// in transition, blend proportionally between the two fogs
+		mid = (self.mins + self.maxs) * 0.5;
+		dorg = other.origin + other.view_ofs - mid;
+		
+		f = dorg * self.movedir;
+		f = (f / self.distance) + 0.5;
+		
+		lerp_density = lerp(ent_density, ent_density2, f);
+		lerp_color = lerpVector(self.fog_color, self.fog_color2, f);
+		lerp_sdensity = lerp(ent_sdensity, ent_sdensity2, f);
+	}
+
+	if (self.fog_density || self.fog_density2) fog_set(other, lerp_density, lerp_color);
+	if (self.skyfog_density || self.skyfog_density2) skyfog_set(other, lerp_sdensity);
+	
+	self.rad_time = time;
+	self.attack_finished = time + FOG_INTERVAL;
+	
+	// reset client's fogblend_entity in case it's currently being transitioned by another entity
+	other.fogblend_entity = world;
+}
+
+
+/*QUAKED trigger_fogblend (.5 .5 .2) ?
+Acts as a smoothly blending portal between two zones of different fog. Sets the fog for any client passing through it, blending their global fog settings between "fog_color"/"fog_density" and "fog_color2"/"fog_density2" proportional to their position within the trigger.
+The axis of motion on which the blend happens is defined by "angle", pointing to whatever zone has color2 and density2.  Trigger therefore has two 'sides' - the side that "angle" points to, and the opposite side.  
+
+"distance" - override the length of the blend period in world units - defaults to bounds size 
+	on 'angle' otherwise. this is only useful for diagonal triggers.
+
+CAVEATS:
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering.
+*/
+/*FGD
+@SolidClass base(Appearflags, Targetname, Target, FogShift) = trigger_fogblend : 
+"Trigger: Fog Blend
+Acts as a smoothly blending portal between two zones of different fog. Sets the fog for any client passing through it, blending their global fog settings between start and end values proportional to their position within the trigger.
+
+- will 'stuffcmd' 2 dozen times per frame so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	distance(integer) : "Length of blend distance (defaults to size of trigger)"
+	angle(integer) : "Axis of motion of blend (points toward end values)"
+]
+*/
+void() trigger_fogblend =
+{
+	if (self.angles == '0 0 0')		// InitTrigger assumes angle 0 means no angle
+		self.angles = '0 360 0';
+
+	InitTrigger ();
+	self.touch = fog_blendTouch;
+	self.distance = zeroconvertdefault(self.distance, BoundsAngleSize(self.movedir, self.size));
+
+	//SUB_CheckWaiting();
+}
+
+
+/*
+================
+fog_blendTimeThink
+used by both trigger_fog and target_fogblend
+================
+*/
+
+float FOGBLEND_ONEWAY = 1;
+float FOGBLEND_REVERSE = 2;
+float FOGBLEND_ALLCLIENTS = 4;
+float FOGBLEND_BLENDTO = 8;
+
+void(entity cl, float sTo, float f) skyfog_blendSetFraction = {
+	float s;
+
+	s = lerpHermite(cl.skyfog_density2, sTo, f);
+	
+	//eprint(cl);
+	//dprint3("Fraction skyfog density: ", ftos(s), "\n");
+	
+	skyfog_set(cl, s);
+};
+
+void(entity cl, vector cTo, float dTo, float f) fog_blendSetFraction = {
+	float d;
+	vector c;
+
+	d = lerpHermite(cl.fog_density2, dTo, f);
+	c = lerpVectorHermite(cl.fog_color2, cTo, f);
+
+	/*
+	eprint(cl);
+	dprint3("fog density: ", ftos(d), "\n");
+	dprint3("color: ", vtos(c), "\n");
+	dprint3("fraction: ", ftos(f), "\n");
+	*/
+
+	fog_set(cl, d, c);
+};
+
+void() fog_blendTimeThink = {
+	float f;
+	float dTo, sTo;
+	vector cTo;
+	
+	if (time >= self.pain_finished)	{
+		f = 1;
+	}
+	else {
+		self.nextthink = time + FOG_INTERVAL;
+		if (self.state && self.speed)
+			f = 1 - (self.pain_finished - time) / self.speed;
+		else if (self.speed2)
+			f = 1 - (self.pain_finished - time) / self.speed2;
+		else
+			f = 1;
+	}
+
+	if (self.state) {
+		dTo = self.fog_density2;
+		cTo = self.fog_color2;
+		sTo = self.skyfog_density2;
+	}
+	else {
+		dTo = self.fog_density;
+		cTo = self.fog_color;
+		sTo = self.skyfog_density;
+	}
+
+	if (self.spawnflags & FOGBLEND_ALLCLIENTS) {
+		entity pl;
+		pl = nextent(world);
+		while (pl.flags & FL_CLIENT) {
+			if (pl.fogblend_entity == self) {
+				if (dTo && !(pl.fog_density2 == dTo && pl.fog_color2 == cTo))
+					fog_blendSetFraction(pl, cTo, zeroconvert(dTo), f);
+
+				if (sTo)
+					skyfog_blendSetFraction(pl, zeroconvert(sTo), f);
+
+				if (time >= self.pain_finished) 
+					pl.fogblend_entity = world;
+			}
+
+			pl = nextent(pl);
+		}
+	}
+	else {
+		if (self.enemy.fogblend_entity == self) {
+			if (dTo && !(self.enemy.fog_density2 == dTo && self.enemy.fog_color2 == cTo))
+				fog_blendSetFraction(self.enemy, cTo, zeroconvert(dTo), f);
+
+			if (sTo)
+				skyfog_blendSetFraction(self.enemy, zeroconvert(sTo), f);
+
+			if (time >= self.pain_finished) {
+				self.enemy.fogblend_entity = world;
+
+			}
+		}
+	}
+
+	if (self.classname == "fog_controller"){
+		if (self.enemy.fogblend_entity != self || time >= self.pain_finished) {
+			remove(self);
+			return;
+		}
+	}
+};
+
+
+
+/**************************************
+
+target_fogblend
+
+**************************************/
+
+void() target_fogblend_use = {
+
+	self.enemy = activator;
+	if (self.enemy.classname != "player") return;
+
+
+	if (!(self.spawnflags & FOGBLEND_ONEWAY))
+		self.state = 1 - self.state;
+	
+	if (self.state)
+		self.pain_finished = time + self.delay + self.speed;
+	else
+		self.pain_finished = time + self.delay + self.speed2;
+
+
+	if (self.spawnflags & FOGBLEND_ALLCLIENTS) {
+		entity pl;
+		pl = nextent(world);
+		while (pl.flags & FL_CLIENT) {
+			if (self.fog_density) fog_save_to_previous(pl);
+			if (self.skyfog_density) skyfog_save_to_previous(pl);
+
+			pl.fogblend_entity = self;
+
+			pl = nextent(pl);
+		}
+	}
+	else {
+		if (self.fog_density) fog_save_to_previous(self.enemy);
+		if (self.skyfog_density) skyfog_save_to_previous(self.enemy);
+
+		self.enemy.fogblend_entity = self;
+	}
+
+	self.nextthink = time + self.delay;
+};
+
+
+
+
+/*QUAKED target_fogblend (.5 .5 .2) (-8 -8 -8) (8 8 8) ONE_WAY REVERSE GLOBAL BLENDTO
+Blends the fog for a client.  activator's fog will be blended from "fog_color" and "fog_density"
+to "fog_color2" and "fog_density2".  Triggering again will blend it back, unless ONE_WAY is set.
+Set REVERSE if you're tired of swapping the values by hand.
+Set GLOBAL to affect all clients in multiplayer, not just the activator.
+
+"delay" - pause before beginning to blend
+"speed" - time to spend blending, -1 for an instant change to fog2.
+"speed2" - time to spend blending back, if different than "speed". -1 for instant.
+
+CAVEATS:
+- will 'stuffcmd' 2 dozen times per frame so try not to make this take too long
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering.
+*/
+/*FGD
+@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend : 
+"Target: Fog Blend
+Activator's fog will be blended over time from start to end values.
+
+- will 'stuffcmd' 2 dozen times per frame so try not to make this take too long
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering." 
+[
+	spawnflags(flags) = [
+		1 : "One-Way Only" : 0
+		2 : "Reverse Start/End" : 0
+		4 : "All clients" : 0
+	]
+	delay(string) : "Pause before starting blend"
+	speed(string) : "Time to blend (-1 for instant)"
+	speed2(string) : "Time to blend back, if different (-1 for instant)"
+]
+*/
+void() target_fogblend =
+{
+
+	if (!self.fog_density && !self.skyfog_density) {
+		objerror("Neither fog density nor skyfog density set");
+		return;
+	}
+
+	self.use = target_fogblend_use;
+	self.think = fog_blendTimeThink;
+
+	if (self.spawnflags & FOGBLEND_REVERSE)
+		self.state = 1;
+	else
+		self.state = 0;
+
+	if (self.spawnflags & FOGBLEND_ONEWAY)
+		self.state = 1 - self.state;
+	
+	if (!self.speed) self.speed = 1;
+	if (!self.speed2) self.speed2 = self.speed;
+	
+	if (self.speed == -1) self.speed = 0;
+	if (self.speed2 == -1) self.speed2 = 0;
+}
+
+
+
+/**************************************
+
+trigger_fog
+
+**************************************/
+
+void() trigger_fog_touch = {
+	//if(self.estate != STATE_ACTIVE)
+	//	return;
+
+	if (!(other.flags & FL_CLIENT))
+		return;
+
+	// fog already set to this value
+	if (other.fog_color == self.fog_color && other.fog_density == self.fog_density)
+		return;
+
+	// transition already occurring from this trigger
+	if (other.fogblend_entity.owner == self)
+		return;
+
+	if (self.fog_density) fog_save_to_previous(other);
+	if (self.skyfog_density) skyfog_save_to_previous(other);
+	
+	// spawn a temp entity to control the transition for this client
+	entity controller;
+
+	controller = spawn();
+	controller.classname = "fog_controller";
+	controller.owner = self;
+	controller.enemy = other;
+	controller.speed2 = self.speed; // speed2 is used when state is 0
+	controller.fog_color = self.fog_color;
+	controller.fog_density = self.fog_density;
+	controller.skyfog_density = self.skyfog_density;
+
+	controller.pain_finished = time + self.delay + self.speed;
+
+	controller.think = fog_blendTimeThink;
+	controller.nextthink = time + controller.delay;
+
+	other.fogblend_entity = controller;
+};
+
+/*QUAKED trigger_fog (.5 .5 .2) ?
+Smoothly blends touching client's currently applied fog to "fog_color" and "fog_density" over time.
+
+"delay" - pause before beginning to blend.
+"speed" - time to spend blending, -1 for an instant change.
+
+CAVEATS:
+- will 'stuffcmd' 2 dozen times per second so try not to make these huge
+- a bug in most quake engine ports will reset the eye position smoothing that happens when climbing stairs or riding a plat on every frame that a 'stuffcmd' is sent, so fog transitions during upwards motion will cause noticeable stuttering.
+*/
+
+void() trigger_fog = {
+	if (!self.fog_density && !self.skyfog_density) {
+		objerror("Neither fog density nor skyfog density set");
+		return;
+	}
+	InitTrigger ();
+	self.touch = trigger_fog_touch;
+	if (!self.speed) self.speed = 1;
+	//SUB_CheckWaiting();
+};

--- a/fog.qc
+++ b/fog.qc
@@ -140,8 +140,8 @@ void() fog_blendTouch =
 	if (other.health <= 0)
 		return;
 	
-	//if (self.estate != STATE_ACTIVE)
-	//	return;
+	if (self.estate != STATE_ACTIVE)
+		return;
 
 	// fix for only first client getting a fog change when multiple coop clients are touching this at once
 	if (time != self.rad_time)	// because fog is rad
@@ -245,7 +245,7 @@ void() trigger_fogblend =
 	self.touch = fog_blendTouch;
 	self.distance = zeroconvertdefault(self.distance, BoundsAngleSize(self.movedir, self.size));
 
-	//SUB_CheckWaiting();
+	SUB_CheckWaiting();
 }
 
 
@@ -474,8 +474,8 @@ trigger_fog
 **************************************/
 
 void() trigger_fog_touch = {
-	//if(self.estate != STATE_ACTIVE)
-	//	return;
+	if (self.estate != STATE_ACTIVE)
+		return;
 
 	if (!(other.flags & FL_CLIENT))
 		return;
@@ -530,5 +530,6 @@ void() trigger_fog = {
 	InitTrigger ();
 	self.touch = trigger_fog_touch;
 	if (!self.speed) self.speed = 1;
-	//SUB_CheckWaiting();
+
+	SUB_CheckWaiting();
 };

--- a/hiptrig.qc
+++ b/hiptrig.qc
@@ -103,6 +103,7 @@ void() trigger_usekey =
 	self.touch = keytrigger_touch;
 
 	InitTrigger ();
+	SUB_CheckWaiting();
 };
 
 // void() remove_touch =
@@ -143,24 +144,20 @@ trigger_setgravity
 float DT_GRAVTOFF = 8;  // trigger will start off
 
 void() grav_toggle = //dumptruck_ds based on hipnotic blocker_use
-
 {
-if ( !self.state )
-	{
-		self.state = 1;
-	setorigin( self, self.origin - '8000 8000 8000');
-	}
-else
-	{
-		self.state = 0;
-	setorigin( self, self.origin + '8000 8000 8000');
-	}
+	if (self.estate != STATE_ACTIVE) 
+		self.state = STATE_ACTIVE;
+	else 
+		self.estate = STATE_INACTIVE;
+	
 };
 
 void() trigger_gravity_touch =
 {
   // from Copper -- dumptruck_ds
   // if (!CheckValidTouch()) return;
+
+	if (self.estate != STATE_ACTIVE) return;
 
 	local float grav;
 
@@ -213,19 +210,17 @@ void() trigger_setgravity =
 		return;
 
 	InitTrigger ();
+
 	self.use = grav_toggle; // dumptruck_ds
 	self.touch = trigger_gravity_touch;
+
 	if ( self.spawnflags & DT_GRAVTOFF ) //dumptruck_ds
-		 {
-		 self.state = 0;
-		 setorigin( self, self.origin + '8000 8000 8000' );
-		 }
-	else
-		{
-		 self.state = 1;
-	 }  //end dumptruck_ds
+		self.estate = STATE_INACTIVE;
+
 	if (!self.gravity)
 		self.gravity = -1;
 	else
-	      self.gravity = ((self.gravity - 1) / 100);
+	    self.gravity = ((self.gravity - 1) / 100);
+
+	SUB_CheckWaiting();
 };

--- a/math.qc
+++ b/math.qc
@@ -90,3 +90,46 @@ float(float value, float minValue, float maxValue) wrap = {
 
     return mod(value - minValue, range + 1) + minValue;
 };
+
+
+
+float(float a, float b, float mix) lerp =
+{
+    if (mix <= 0) return a;
+    if (mix >= 1) return b;
+    return (b * mix + a * ( 1 - mix ) );
+}
+
+vector(vector a, vector b, float mix) lerpVector =
+{
+    if (mix <= 0) return a;
+    if (mix >= 1) return b;
+    return (b * mix + a * ( 1 - mix ) );
+}
+
+// for a relaxing lerp: hermite lerp.
+float(float a, float b, float mix) lerpHermite =
+{
+    if (mix <= 0) return a;
+    if (mix >= 1) return b;
+    
+    local float h01;
+    
+    h01 = mix * mix;
+    h01 *= 3 - 2 * mix;
+    
+    return (b * h01 + a * ( 1 - h01 ) );
+}
+
+vector(vector a, vector b, float mix) lerpVectorHermite =
+{
+    if (mix <= 0) return a;
+    if (mix >= 1) return b;
+
+    local float h01;
+    
+    h01 = mix * mix;
+    h01 *= 3 - 2 * mix;
+    
+    return (b * h01 + a * ( 1 - h01 ) );
+}

--- a/progs.src
+++ b/progs.src
@@ -3,6 +3,10 @@
 defs.qc //added fields, see comments for details
 newflags.qc //new spawnflags for all entities
 subs.qc //modified targets, triggers and killtargets
+
+math.qc // Code by Joshua Skelton
+utility.qc
+
 fight.qc
 customsounds.qc //mapper-settable custom sound effects for monsters - iw
 custom_mdls.qc //mapper-settable custom models for monsters - iw
@@ -23,6 +27,7 @@ triggers.qc //added trigger_push_custom based on Hipnotic
 plats.qc
 misc.qc
 lights.qc //c0burn's excellent switchable lights
+fog.qc // fog triggers
 
 ogre.qc
 demon.qc
@@ -42,9 +47,8 @@ shalrath.qc		// registered
 enforcer.qc		// registered
 oldone.qc		// registered
 oldone2.qc		// killable Shub
-
 dtmisc.qc // sound code from Hipnotic & Rubicon Rumble and misc visual effects
-math.qc // Code by Joshua Skelton
+
 misc_model.qc // Code by Joshua Skelton
 hipcount.qc //Hipnotic counter
 hippart.qc //Hipnotic particlefield and func_togglewall

--- a/rubicon2.qc
+++ b/rubicon2.qc
@@ -577,6 +577,8 @@ void() trigger_ladder =
 
 	InitTrigger ();
 	self.touch = ladder_touch;
+
+	SUB_CheckWaiting();
 };
 /*
 ===============================================================================

--- a/subs.qc
+++ b/subs.qc
@@ -26,6 +26,24 @@ void() SetMovedir =
 	self.angles = '0 0 0';
 };
 
+
+/*
+=============
+SUB_CallAsSelf
+
+wrap the self/oself shuffle for code cleanliness elsewhere
+===============
+*/
+void(void() fun, entity newself) SUB_CallAsSelf =
+{
+	local entity oself;
+	
+	oself = self;
+	self = newself;
+	fun();
+	self = oself;	
+}
+
 /*
 ================
 InitTrigger
@@ -255,6 +273,7 @@ void() SUB_UseTargets =
 //	local entity t, stemp, otemp, act;
 	local entity t;
 
+	if (self.estate != STATE_ACTIVE) return;
 //
 // check for a delay
 //
@@ -599,6 +618,8 @@ float() CheckValidTouch =
 	if (other.health <= 0)
 		return FALSE;
 	if (other.movetype == MOVETYPE_NOCLIP)
+		return FALSE;
+	if (self.estate != STATE_ACTIVE)
 		return FALSE;
 	return TRUE;
 }

--- a/subs.qc
+++ b/subs.qc
@@ -299,11 +299,22 @@ void() SUB_UseTargets =
 //
 // print the message
 //
-	if (activator.classname == "player" && self.message != "")
-	{
-		centerprint (activator, self.message);
-		if (!self.noise)
-			sound (activator, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
+	if (self.message != "") {
+		if (self.spawnflags & TRIGGER_CENTERPRINTALL) {
+			t = find(world, classname, "player");
+			while (t) {
+				centerprint (t, self.message);
+				if (!self.noise)
+					sound (t, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
+				t = find(t, classname, "player");
+			}
+		}
+		
+		else if (activator.classname == "player") {
+			centerprint (activator, self.message);
+			if (!self.noise)
+				sound (activator, CHAN_VOICE, "misc/talk.wav", 1, ATTN_NORM);
+		}	
 	}
 
 //

--- a/triggers.qc
+++ b/triggers.qc
@@ -13,6 +13,34 @@ float	SPAWNFLAG_NOMESSAGE = 1;
 float	SPAWNFLAG_NOTOUCH = 1;
 float SPAWNFLAG_TURNS_OFF = 2; //used for Wait for retrigger spawnflag
 
+
+void() SUB_EndWaiting = {
+	self.is_waiting = 0;
+	self.estate = STATE_ACTIVE;
+	if (self.use == SUB_EndWaiting) self.use = self.dormant_use;
+
+	// special case for teleports, makes it ignore the fact that it has a targetname when touched
+	if (self.classname == "trigger_teleport") {
+		self.is_waiting = -1;
+	}
+};
+
+void() SUB_CheckWaiting = {
+	if (self.is_waiting > 0) {
+		self.dormant_use = self.use;
+		self.use = SUB_EndWaiting;
+		self.estate = STATE_INACTIVE;
+
+		dprint("Spawned a waiting ");
+		dprint(self.classname);
+		dprint(" with targetname ");
+		dprint(self.targetname);
+		dprint(" and target ");
+		dprint(self.target);
+		dprint("\n");
+	}
+};
+
 // the wait time has passed, so set back up for another activation
 void() multi_wait =
 {
@@ -61,7 +89,8 @@ void() multi_trigger =
 		self.nextthink = time + self.wait;
 		if (self.spawnflags & SPAWNFLAG_TURNS_OFF)
 		{
-			self.is_waiting = TRUE;
+			self.is_waiting = 1;
+			SUB_CheckWaiting();
 		}
 	}
 	else
@@ -75,7 +104,7 @@ void() multi_trigger =
 
 void() multi_killed = //dumptruck_ds
 {
-	if (self.is_waiting)	// Supa, restore health and do nothing if we're still waiting to be activated
+	if (self.estate != STATE_ACTIVE)	// Supa, restore health and do nothing if we're still waiting to be activated
 	{
 		self.health		= self.max_health;	// nyah nyah~!
 		self.takedamage	= DAMAGE_YES;
@@ -90,13 +119,6 @@ void() multi_killed = //dumptruck_ds
 
 void() multi_use = //dumptruck_ds
 {
-	if (self.is_waiting)	// Supa, if this trigger is waiting to be activated we'll tell it to get ready!
-	{
-		self.is_waiting = FALSE;	// Get ready!
-
-		return;	// Must be used or triggered again to do anything
-	}
-
 	self.enemy = activator;
 	multi_trigger();
 };
@@ -111,7 +133,7 @@ void() multi_touch = //dumptruck_ds
 	if (other.movetype == MOVETYPE_NOCLIP)
 		return;
 
-	if (self.is_waiting)	// Supa, is this trigger waiting to be activated?
+	if (self.estate != STATE_ACTIVE)
 		return;
 
 // if the trigger has an angles field, check player's facing direction
@@ -145,17 +167,6 @@ void() trigger_multiple =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
-
-	if (self.is_waiting)
-	{
-		dprint("Spawned a waiting ");
-		dprint(self.classname);
-		dprint(" with targetname ");
-		dprint(self.targetname);
-		dprint(" and target ");
-		dprint(self.target);
-		dprint("\n");
-	}
 
 	if (self.sounds == 1)
 	{
@@ -202,6 +213,8 @@ void() trigger_multiple =
 			self.touch = multi_touch;
 		}
 	}
+
+	SUB_CheckWaiting();
 };
 
 
@@ -281,6 +294,8 @@ void() trigger_secret =
 
 void() counter_use =
 {
+	if (self.estate != STATE_ACTIVE) return;
+
 	self.count = self.count - 1;
 	if (self.count < 0)
 		return;
@@ -464,6 +479,8 @@ void() teleport_touch =
 {
 local entity	t;
 local vector	org;
+
+	if (self.estate != STATE_ACTIVE) return;
 
 	if (self.targetname != "")
 	{
@@ -677,13 +694,6 @@ void() info_teleport_random =
 
 void() teleport_use =
 {
-	if (self.is_waiting)	// Supa, if this trigger is waiting to be activated we'll tell it to get ready!
-	{
-		self.is_waiting = -1;	// Special case to tell teleport_touch to ignore the usual targetname->nextthink check
-
-		return;	// Must be used or triggered again to do anything
-	}
-
 	self.nextthink = time + 0.2;
 	force_retouch = 2;		// make sure even still objects get hit
 	self.think = SUB_Null;
@@ -726,6 +736,8 @@ MONSTER_ONLY(16) will only teleport monsters
 		o = (self.mins + self.maxs)*0.5;
 		ambientsound (o, "ambience/hum1.wav",0.5 , ATTN_STATIC);
 	}
+
+	SUB_CheckWaiting();
 };
 
 /*
@@ -755,6 +767,8 @@ void() trigger_setskill =
 
 	InitTrigger ();
 	self.touch = trigger_skill_touch;
+
+	SUB_CheckWaiting();
 };
 
 
@@ -801,6 +815,8 @@ void() trigger_onlyregistered =
 	precache_sound ("misc/talk.wav");
 	InitTrigger ();
 	self.touch = trigger_onlyregistered_touch;
+
+	SUB_CheckWaiting();
 };
 
 //============================================================================
@@ -813,6 +829,9 @@ void() hurt_on =
 
 void() hurt_touch =
 {
+
+	if (self.estate != STATE_ACTIVE) return;
+
 	// from Copper -- dumptruck_ds
 	if (other.movetype == MOVETYPE_NOCLIP)
 		return;
@@ -842,6 +861,8 @@ void() trigger_hurt =
 	self.touch = hurt_touch;
 	if (!self.dmg)
 		self.dmg = 5;
+
+	SUB_CheckWaiting();
 };
 
 //============================================================================
@@ -857,7 +878,8 @@ float DT_NOISE = 32; // use custom sound using noise key/value
 
 void() trigger_push_touch =
 {
-	if (self.is_waiting) return;
+	if (self.estate != STATE_ACTIVE) return;
+
 	// from Copper -- dumptruck_ds
 	if (other.movetype == MOVETYPE_NOCLIP)
 		return;
@@ -911,6 +933,9 @@ void() trigger_push = //dumptruck_ds
 
 	if (!self.speed)
 		self.speed = 1000;
+
+
+	SUB_CheckWaiting();
 };
 
 void() push_toggle = //dumptruck_ds based on hipnotic blocker_use
@@ -977,6 +1002,8 @@ void() trigger_push_custom =
 
 void() trigger_monsterjump_touch =
 {
+	if (self.estate != STATE_ACTIVE) return;
+
 	if ( other.flags & (FL_MONSTER | FL_FLY | FL_SWIM) != FL_MONSTER )
 		return;
 
@@ -1025,6 +1052,8 @@ void() trigger_monsterjump =
 		self.angles = '0 360 0';
 	InitTrigger ();
 	self.touch = trigger_monsterjump_touch;
+
+	SUB_CheckWaiting();
 };
 //////////////////////////////////////////////////////////////////////////////
 // end dumptruck_ds additions //////////////////////////////////////////////
@@ -1037,6 +1066,8 @@ float 	PLAYER_SAFE = 2;
 
 void() trigger_void_touch =
 {
+	if (self.estate != STATE_ACTIVE) return;
+
 	if (other.movetype == MOVETYPE_NOCLIP) // from Copper -- dumptruck_ds
 		return FALSE;
 
@@ -1074,6 +1105,8 @@ void() trigger_void =
 
 	InitTrigger ();
 	self.touch = trigger_void_touch;
+
+	SUB_CheckWaiting();
 };
 
 /*==============================================================================
@@ -1197,6 +1230,8 @@ void() trigger_take_weapon =
 	self.wait = -1;
 	trigger_multiple();
 	self.touch = take_weapon_use;
+
+	SUB_CheckWaiting();
 };
 
 void(float newtrack) changemusic =
@@ -1239,6 +1274,8 @@ void() trigger_changemusic =
 		}
 	InitTrigger();
 	self.touch = trigger_changemusic_touch;
+
+	SUB_CheckWaiting();
 };
 
 void() trigger_cdtrack_use = //point entity version uses count for music track number for backwards compatibly in Adoria mod -- dumptruck_ds
@@ -1368,10 +1405,14 @@ void() trigger_look =
 
     InitTrigger();
     self.touch = onlookat_touch;
+
+    SUB_CheckWaiting();
 };
 
 void() trigger_target_change_use =
 {
+	if (self.estate != STATE_ACTIVE) return;
+
     for (entity e = world; (e = find(e, targetname, self.target)); )
     {
       if (!self.cnt || self.cnt == 1)
@@ -1408,4 +1449,106 @@ void() trigger_changetarget =
         return;
 
     self.use = trigger_target_change_use;
+};
+
+
+
+
+/*
+=============================================================
+
+target_setstate
+
+=============================================================
+*/
+float SETSTATE_STARTOFF = 1;
+float SETSTATE_CLOSEALLDOORS = 2;
+float SETSTATE_DONTRESETBUTTON = 4;
+
+float(entity e) entity_get_state = {
+	if(e.classname == "func_door") return e.owner.estate;
+	else return e.estate;
+};
+
+void(entity e, float state, float flags) entity_set_state = {
+	float closealldoors;
+
+	if(e.classname == "func_button") {
+		if (state == STATE_ACTIVE) button_unlock(e, flags & SETSTATE_DONTRESETBUTTON);
+		else button_lock(e);
+	}
+	else if(e.classname == "func_door") {
+		if (flags & SETSTATE_CLOSEALLDOORS) closealldoors = 1;
+
+		if (state == STATE_ACTIVE) door_estate_unlock(e, closealldoors);
+		else door_estate_lock(e, closealldoors);
+	}
+	else e.estate = state;
+
+	if (e.is_waiting > 0 && state == STATE_ACTIVE) {
+		SUB_CallAsSelf(SUB_EndWaiting, e);
+	}
+
+	//if (e.touch && e.touch != SUB_Null) {
+	//	force_retouch = 2;
+	//}
+};
+
+void(string matchstring, .string matchfield, float state, float flags) target_setstate_set_target = {
+	local entity t;
+
+	t = find (world, matchfield, matchstring);
+	while (t != world) {
+		if(state == -1){
+			if(entity_get_state(t) == STATE_ACTIVE) entity_set_state(t, STATE_INACTIVE, flags);
+			else entity_set_state(t, STATE_ACTIVE, flags);
+		}
+		else entity_set_state(t, state, flags);
+
+		t = find (t, matchfield, matchstring);
+	}
+};
+
+void(float state) target_setstate_set_alltargets = {
+	if (self.target && self.target != "") {
+		target_setstate_set_target(self.target, targetname, state, self.spawnflags);
+		target_setstate_set_target(self.target, targetname2, state, self.spawnflags);
+	}
+	if (self.target2 && self.target2 != "") {
+		target_setstate_set_target(self.target2, targetname, state, self.spawnflags);
+		target_setstate_set_target(self.target2, targetname2, state, self.spawnflags);
+	}
+	if (self.target3 && self.target3 != "") {
+		target_setstate_set_target(self.target3, targetname, state, self.spawnflags);
+		target_setstate_set_target(self.target3, targetname2, state, self.spawnflags);
+	}
+	if (self.target4 && self.target4 != "") {
+		target_setstate_set_target(self.target4, targetname, state, self.spawnflags);
+		target_setstate_set_target(self.target4, targetname2, state, self.spawnflags);
+	}
+};
+
+void() target_setstate_use = {
+	local float state;
+
+	if (self.style == 1) state = STATE_ACTIVE;
+	else if (self.style == 2) state = STATE_INACTIVE;
+	else state = -1;
+
+	target_setstate_set_alltargets(state);
+
+};
+
+void() target_setstate_startoff_think = {
+	target_setstate_set_alltargets(STATE_INACTIVE);
+};
+
+void() target_setstate = {
+	self.use = target_setstate_use;
+
+	if(self.spawnflags & SETSTATE_STARTOFF) {
+		// wait a bit while doors finish being set up
+		self.think = target_setstate_startoff_think;
+		self.nextthink = time + 0.2;
+	}
 };

--- a/triggers.qc
+++ b/triggers.qc
@@ -551,6 +551,8 @@ if (!(self.spawnflags & TELE_STEALTH))
 	other.angles = t.mangle;
 	if (other.classname == "player")
 	{
+		fog_setFromEnt(other, t); // retrieves fog values from teleport destination, if any
+
 		other.fixangle = 1;		// turn this way immediately
 		other.teleport_time = time + 0.7;
 		if (other.flags & FL_ONGROUND)

--- a/utility.qc
+++ b/utility.qc
@@ -1,0 +1,218 @@
+void(string s, string ss) dprint2 = 
+	{ dprint(s); dprint(ss); }
+void(string s, string ss, string sss) dprint3 = 
+	{ dprint(s); dprint(ss); dprint(sss); }
+void(string s, string ss, string sss, string ssss) dprint4 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); }
+void(string s, string ss, string sss, string ssss, string sssss) dprint5 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); dprint(sssss); }
+void(string s, string ss, string sss, string ssss, string sssss, string ssssss) dprint6 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); dprint(sssss); dprint(ssssss);}
+void(string s, string ss, string sss, string ssss, string sssss, string ssssss, string sssssss) dprint7 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); dprint(sssss); dprint(ssssss); dprint(sssssss);}
+void(string s, string ss, string sss, string ssss, string sssss, string ssssss, string sssssss, string ssssssss) dprint8 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); dprint(sssss); dprint(ssssss); dprint(sssssss); dprint(ssssssss); }
+void(string s, string ss, string sss, string ssss, string sssss, string ssssss, string sssssss, string ssssssss, string sssssssss) dprint9 = 
+	{ dprint(s); dprint(ss); dprint(sss); dprint(ssss); dprint(sssss); dprint(ssssss); dprint(sssssss); dprint(ssssssss); dprint(sssssssss); }
+
+/**********************************
+ Sourced from utility.qc from smej2
+ **********************************/
+
+
+float(float in) bprint_int =
+{
+	in = floor(in);
+	if (in <= 0) return 0;
+	
+	float digit;
+	digit = in - bprint_int(in / 10);
+	
+	switch(digit) {
+	case 9:
+		bprint("9"); break;
+	case 8:
+		bprint("8"); break;
+	case 7:
+		bprint("7"); break;
+	case 6:
+		bprint("6"); break;
+	case 5:
+		bprint("5"); break;
+	case 4:
+		bprint("4"); break;
+	case 3:
+		bprint("3"); break;
+	case 2:
+		bprint("2"); break;
+	case 1:
+		bprint("1"); break;
+	case 0:
+		bprint("0"); break;
+	}
+	
+	return in * 10;
+}
+
+
+float(float in, float def) defaultFl = {
+	if (in) return in;
+	else return def;
+}
+
+
+// shorthand for turning -1 to 0 for keyvalues for which 0 is a valid non-default selection
+float(float in) zeroconvert =
+{
+	if (in == -1) return 0;
+	return in;
+}
+float(float in, float def) zeroconvertdefault =
+{
+	if (in == -1) return 0;
+	if (in == 0) return def;
+	return in;
+}
+
+
+
+
+// for measuring how large an entity is along an arbitrary vector
+// FIXME: this is trash and it returns trash
+float(vector v, vector s) BoundsAngleSize =
+{
+	v_x = fabs(v_x);
+	v_y = fabs(v_y);
+	v_z = fabs(v_z);
+	
+	// size is always + + + but this is in case I switch the parameters somewhere
+	s_x = fabs(s_x);
+	s_y = fabs(s_y);
+	s_z = fabs(s_z);
+	
+	return v * s;
+}
+
+//count -4 = numclients in coop
+/*void(.float fld) playercount_convert =
+{
+	if (self.fld != -4) return;
+	if (!coop)
+		self.fld = 1;
+	else
+		self.fld = clients;
+}
+*/
+
+
+// wonderful stuffcmd code from Honey by czg
+
+/*
+=============
+stuffcmd_float
+
+This is a horrible hack that I am ashamed of!
+===============
+*/
+void stuffcmd_digit( entity client, float f) =
+{
+	float d;
+	d = floor(f);
+	d = mod(d, 10);
+
+	//CLOSE YOUR EYES, HONEY! DON'T LOOK!
+	if(d == 0)
+		stuffcmd(client, "0");
+	else if(d == 1)
+		stuffcmd(client, "1");
+	else if(d == 2)
+		stuffcmd(client, "2");
+	else if(d == 3)
+		stuffcmd(client, "3");
+	else if(d == 4)
+		stuffcmd(client, "4");
+	else if(d == 5)
+		stuffcmd(client, "5");
+	else if(d == 6)
+		stuffcmd(client, "6");
+	else if(d == 7)
+		stuffcmd(client, "7");
+	else if(d == 8)
+		stuffcmd(client, "8");
+	else if(d == 9)
+		stuffcmd(client, "9");	
+}
+
+void stuffcmd_int( entity client, float f, float numdigits) =
+{
+	
+	float tmp;
+
+	
+	if(f == 0)
+	{
+		stuffcmd( client, "0");
+		return;
+	}
+
+	if(f < 0)
+	{
+		// Yeah sure.
+		stuffcmd( client, "-");
+		f = fabs(f);
+	}
+	
+	if(numdigits <= 0)
+	{
+		tmp = f;
+		numdigits = 1;
+		while(tmp >= 1){
+			tmp = tmp / 10;
+			numdigits = numdigits * 10;
+		}
+	}
+	
+	//I don't know what I'm thinking here...
+	//I need to do this to get zero-padding to work.
+
+	while( numdigits > 1 )
+	{
+		numdigits = numdigits / 10;
+		tmp = f / numdigits;
+		stuffcmd_digit( client, tmp);
+	}
+}
+
+void stuffcmd_float( entity client, float f) =
+{
+	float intpart, decpart, isNegative;
+	
+	isNegative = FALSE;
+	
+	if(f == 0)
+	{
+		stuffcmd( client, "0");
+		return;
+	}
+	
+	if(f < 0)
+	{
+		// easier this way
+		isNegative = TRUE;
+		f = fabs(f);
+	}	
+	
+	// 1: stuff the integer part.
+	intpart = floor(f);
+	if(isNegative) 
+		stuffcmd( client, "-");
+	stuffcmd_int( client, intpart, 0);
+	
+	// 2: stuff the decimal point.
+	stuffcmd( client, ".");
+	
+	// 3: stuff the decimal part.
+	decpart = mod( f, 1);
+	decpart = decpart * 10000;
+	stuffcmd_int( client, decpart, 10000);
+}

--- a/world.qc
+++ b/world.qc
@@ -531,6 +531,16 @@ void() StartFrame =
 	teamplay = cvar("teamplay");
 	skill = cvar("skill");
 	framecount = framecount + 1;
+
+	if (cleanUpClientStuff)
+		cleanUpClientStuff -= 1;
+	else if (!gamestarted && framecount > 2)
+	{
+		if (framecount != 3)
+			cleanUpClientStuff += 2;
+		
+		gamestarted = TRUE;
+	}
 };
 
 /*


### PR DESCRIPTION
### Fog system
Closes #144 

You can set a fog value into all player start entities, teleport destinations, and intermission cameras, so the fog will change instantly to the set value when a player makes use of them. This way, the player's view can move to a different fog zone without having to pass through a fog trigger.

An important note from Copper about this fog system:

> The fog keyvalue that goes on Worldspawn doesn't interact with this system. It is a feature of various engines (such as those in the Fitzquake family) and isn't interpreted by game code. The reason for this is that it's interpreted as four values (one for density and three for color) and set by the engine at load time. The numeric fields that are passed on to the game code (ie Copper), however, can only be one value (a float) or three (a vector). If you set fog in your world with a fog parameter on worldspawn, and never bother with fog_color and fog_density on any entities, you'll get the usual static global fog the way it's always worked. Color and density on a player start will be evaluated on the first frame of gameplay, and will override any fog set by the engine.

Setting the fog density to -1 will disable the fog.

**Blending fog between two areas**

Using the trigger_fogblend brush entity, you can smoothly blend between two fog values as the player moves across the trigger. It's not temporal-based, instead it's based on how far the player moves within it.

This way, you can place one along a corridor for example, and the fog will seamlessly change as the player walks.

**Time-based fog blending**

The trigger_fog brush entity blends the player's current fog into another when touched, within a customizable transition time.

And the target_fogblend point entity toggles the activating player's fog between two different settings, also with a custom transition time. The first activation makes it blend in from the current fog, and the subsequent ones make it toggle between two values. You can optionally set the fog to be applied to all players.

**Sky fog**

All entities that change the fog can change skyfog density as well, with the key skyfog_density/skyfog_density2. The same transitions to the usual fog apply to skyfog.

If you want to disable skyfog, set the field to -1. Leaving it unset, or set to 0, will keep the skyfog unchanged. In case you want to change only the skyfog density and not change the standard fog, set fog_density to 0.

----------------------------------------------------------------
### State System
Closes #143

Alkaline has a state system somewhat similar to AD's "estate" system and Copper's target_lock entity. With it you can disable/enable entities at will, giving you greater control over complex map scripting and events. Entity behaviour when disabled is class-dependant.

You set an entity's state using the target_setstate point entity. You can directly disable, enable, or toggle the state. Target entities can start the map already disabled through the spawnflag Targets start disabled.

If you need to target an entity that has its behaviour changed when given a targetname (like func_door or trigger_teleport), you can make the target_setstate target the entity's targetname2 field.

This system is integrated with dormant triggers (is_waiting key), meaning that you can "wake" a trigger not only by triggering it, but also by using a target_setstate on it.

The entity's state is kept under the estate field, which 0 meaning enabled/normal operation, and 1 disabled. So for triggers, you're able make them start off by to directly setting this value to 1. You cannot do that to doors nor buttons though, in those cases you need to use a target_setstate with "start disabled" set.

A lot of entities support enabling/disabling:
**Trigger brushes of any class**

When disabled, all trigger_* brush entities get their touch action turned off. This includes self-sufficient entities that don't need to target anything, like fog triggers, ladders, monsterjumps, changelevels, etc.

Also, any entity that fire their targets won't do it while disabled (like trigger_relay), and a trigger_counter won't get its use count increased.
**Doors**

Like in Copper, disabling a door makes it not respond to touches or triggers, and disables its trigger field.

Doors will also close immediately when disabled. Toggling doors or with wait -1 set won't close by default, but you can change that behaviour using the spawnflag Close all doors. In this case, if re-enabled, the door will return to the position it was before disabling.
**Buttons**

Also similar to Copper, buttons depress themselves when disabled and cannot be activated.

If the button have a wait -1 value (that is, it's a press-once button), when re-enabled it'll reset back to its un-pressed state regardless if it had been activated before. You can change that using the spawnflag Don't reset button state, in which case it'll revert to its previous state when re-enabled.

--------------------------------------------------------
### Message all players
Closes #139

Every entity that can centerprint a message may be set to broadcast it to all connected players. Good for when you have some map-wide event that you want to communicate in a co-op game for example. Just set the spawnflag message all players on the messaging entity.