### PR TITLE
Fix snd_attack on Grunt styles

### DIFF
--- a/soldier.qc
+++ b/soldier.qc
@@ -64,7 +64,7 @@ void() GruntFireGrenade =
 
 	// self.effects = self.effects | EF_MUZZLEFLASH; //redundant -- dumptruck_ds
 
-	sound (self, CHAN_WEAPON, "weapons/grenade.wav", 1, ATTN_NORM);
+	sound_attack (self, CHAN_WEAPON, "weapons/grenade.wav", 1, ATTN_NORM);
 
 	missile = spawn ();
 	missile.owner = self;
@@ -123,7 +123,7 @@ void() MonFireSpike =
     local vector dir;
     // local entity old;
 
-    sound (self, CHAN_WEAPON, "weapons/spike2.wav", 1, ATTN_NORM);
+    sound_attack (self, CHAN_WEAPON, "weapons/spike2.wav", 1, ATTN_NORM);
     self.attack_finished = time + 0.2;
 
     dir = normalize (self.enemy.origin - self.origin);

--- a/weapons.qc
+++ b/weapons.qc
@@ -625,7 +625,7 @@ void() W_GruntRocket =
 
 	// self.currentammo = self.ammo_rockets = self.ammo_rockets - 1; dumptruck_ds
 
-	sound (self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);
+	sound_attack (self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);
 
 	self.punchangle_x = -2;
 


### PR DESCRIPTION
Makes snd_attack function on nail, rocket and grenade grunts.