### PR TITLE
added custom path alignment to `func_train`

### DIFF
--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -2071,6 +2071,7 @@ Spawnflags:
 - 'Move on trigger' will force the train to resume its path when triggered, even when temporarily waiting at a path_corner.
 - 'Stop on trigger' will stop the train at the next path_corner when triggered. Trigger it again to resume.
 The flags above are mutually exclusive and will cause an objerror when selected simultaneously.
+- 'Custom alignment' allows you to directly specify how the train is offset relative to its path_corners using an 'origin' brush instead of using the vanilla corner alignment.
 "
 [
 	sounds(choices) : "Sound" : 1 =
@@ -2091,6 +2092,7 @@ The flags above are mutually exclusive and will cause an objerror when selected 
 		2: "Move on trigger" : 0
 		4: "Stop on trigger" : 0
 		8: "Non-solid" : 0
+		64: "Custom alignment" : 0
 	]
 ]
 

--- a/plats.qc
+++ b/plats.qc
@@ -220,6 +220,7 @@ float TRAIN_STOPONTRIGGER = 4;
 float TRAIN_NONSOLID = 8;
 float TRAIN_NOROTATE = 16;
 float TRAIN_ROTATEY = 32;
+float TRAIN_CUSTOMALIGN = 64;
 
 float TRAIN_NEXT_WAIT = 0; //normal movement
 float TRAIN_NEXT_STOP = 1; // force a stop on the next path_corner
@@ -388,10 +389,17 @@ void() train_next = {
 		if (self.classname == "misc_modeltrain" && self.style != TRAIN_STYLE_SINGLEANIM)
 			SUB_CallAsSelf(self.animcontroller.think, self.animcontroller);
 	}
+	// if the TRAIN_CUSTOMALIGN flag is checked then the train should align
+	// with its path_corners based on the location of an "origin" brush added
+	// to the train by the mapper instead of the mins corner
+	// -therektafire
+	float doDisplace;
+	if (self.spawnflags & TRAIN_CUSTOMALIGN) doDisplace = 0.0;
+	else doDisplace = 1.0;
 	
 	if (self.classname != "misc_modeltrain") displ = self.mins;
 	
-	SUB_CalcMove(targ.origin - displ, self.speed2, train_wait);
+	SUB_CalcMove(targ.origin - (displ * doDisplace), self.speed2, train_wait);
 };
 
 // searches for the first path_corner after the train entity is initialized
@@ -406,9 +414,13 @@ void() func_train_find = {
 	targ = find(world, targetname, self.target);
 	self.target = targ.target;
 
+	float doDisplace;
+	if (self.spawnflags & TRAIN_CUSTOMALIGN) doDisplace = 0.0;
+	else doDisplace = 1.0;
+	
 	if (self.classname != "misc_modeltrain") displ = self.mins;
 	self.enemy = targ;
-	setorigin(self, targ.origin - displ);
+	setorigin(self, targ.origin - (displ * doDisplace));
 	if (targ.speed) self.speed2 = targ.speed; // uses speed from the 1st path corner if set
 
 	if (!self.targetname)


### PR DESCRIPTION
Added an optional spawnflag to `func_train` that allows you to specify your own origin for the train using an origin brush instead of the vanilla behavior of always orienting it around it's mins corner, should make it a bit nicer to set up train paths since you don't have to take the size of the train into account when setting up the paths since you can align it anywhere. I made it a spawnflag so that it's an opt in thing and you can just use the vanilla behavior instead if you want. Here's a basic demo map showing an example
[train_custom_alignment.map.txt](https://github.com/dumptruckDS/progs_dump_qc/files/8385799/train_custom_alignment.map.txt)
