### PR TITLE
Projectile speed mod

### DIFF
--- a/boss.qc
+++ b/boss.qc
@@ -218,7 +218,7 @@ void(vector p) boss_missile =
 
 	vec = normalize (d - org);
 
-	launch_spike (org, vec);
+	launch_spike2 (org, vec, 300);
 	// setmodel (newmis, "progs/lavaball.mdl");
 	if (self.mdl_proj != "") // dumptruck_ds custom_mdls
 	{
@@ -240,7 +240,6 @@ void(vector p) boss_missile =
 
 	newmis.avelocity = '200 100 300';
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*300;
 	newmis.touch = T_MissileTouch; // rocket explosion
 	sound_attack (self, CHAN_WEAPON, "boss1/throw.wav", 1, ATTN_NORM);
 

--- a/boss2.qc
+++ b/boss2.qc
@@ -367,7 +367,7 @@ void(vector p) boss2_missile =
 
 	vec = normalize (d - org);
 
-	launch_spike (org, vec);
+	launch_spike2 (org, vec, 300);
 	// setmodel (newmis, "progs/lavaball.mdl");
 	if (self.mdl_proj != "") // dumptruck_ds custom_mdls
 	{
@@ -389,7 +389,6 @@ void(vector p) boss2_missile =
 
 	newmis.avelocity = '200 100 300';
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*300;
 	newmis.touch = T_MissileTouch; // rocket explosion
 	sound_attack (self, CHAN_WEAPON, "boss1/throw.wav", 1, ATTN_NORM);
 

--- a/combat.qc
+++ b/combat.qc
@@ -240,16 +240,26 @@ void(entity targ, entity inflictor, entity attacker, float damage) T_Damage=
 			local float mode;
 			mode = 0;
 			// take highest mode so infighting happens consistently
-			if (self.infight_mode > mode)
+			if (self.infight_mode == -1 || self.infight_mode > mode)
 			{
 				mode = self.infight_mode;
 			}
-			if (attacker.infight_mode > mode)
+			if (mode != -1 && attacker.infight_mode > mode)
 			{
 				mode = attacker.infight_mode;
 			}
 			//soldiers of the same style will infight -- dumptruck_ds - thanks for c0burn and Shamblernaut for your help!
-			if (
+			if (mode == -1)
+			{
+				if (attacker.classname == "player")
+				{
+					if (self.enemy.classname == "player")
+						self.oldenemy = self.enemy;
+					self.enemy = attacker;
+					FoundTarget ();
+				}
+			}
+			else if (
 				(self.classname != attacker.classname) ||
 			  ((self.classname == "monster_army") && (self.style == attacker.style)) ||
 				(mode > 0 && self.mdl_body != attacker.mdl_body) || // infight if different models

--- a/defs.qc
+++ b/defs.qc
@@ -540,6 +540,8 @@ float	AS_TURRET		= 5;
 .entity 	movetarget;
 .float		homing;
 .float		projexpl;
+.float		proj_speed_mod;
+.float		proj_basespeed;
 .float		infight_mode;
 
 //

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -74,6 +74,8 @@ void() Laser_Touch =
 void(vector org, vector vec) LaunchLaser =
 {
 
+	local float projspeed = self.proj_speed_mod * 600;
+
 	if (self.classname == "monster_enforcer" || self.classname == "monster_army")
 		sound_attack (self, CHAN_WEAPON, "enforcer/enfire.wav", 1, ATTN_NORM);
 
@@ -109,11 +111,17 @@ void(vector org, vector vec) LaunchLaser =
 
 	setorigin (newmis, org);
 
-	newmis.velocity = vec * 600;
+	newmis.velocity = vec * projspeed;
 	newmis.angles = vectoangles(newmis.velocity);
-
-	newmis.nextthink = time + 5;
-	newmis.think = SUB_Remove;
+	if (self.homing > 0)
+	{
+		SetupHoming(newmis, projspeed);
+	}
+	else
+	{
+		newmis.nextthink = time + 5;
+		newmis.think = SUB_Remove;
+	}
 	newmis.touch = Laser_Touch;
 };
 

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -227,7 +227,7 @@ EnfRocket //dumptruck_ds start -- from inside qc tut http://www.insideqc.com/qct
 void() EnfRocket =
 {
 	local	entity missile;
-
+	local float projspeed = 900 * (self.proj_speed_mod ? self.proj_speed_mod : 1);
 	// self.currentammo = self.ammo_rockets = self.ammo_rockets - 1; dumptruck_ds
 
 	sound_attack (self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);
@@ -242,8 +242,7 @@ void() EnfRocket =
 
 // set missile speed  -- dumptruck_ds below
 
-	missile.velocity = normalize(self.enemy.origin - self.origin);
-  missile.velocity = missile.velocity * 900;
+	SetSpeed(missile, normalize(self.enemy.origin - self.origin), projspeed);
   missile.angles = vectoangles(missile.velocity);
   missile.touch = EnfMisTouch;
 
@@ -255,8 +254,15 @@ void() EnfRocket =
 	// missile.touch = T_MissileTouch;
 
 // set missile duration
-	missile.nextthink = time + 5;
-	missile.think = SUB_Remove;
+	if (self.homing > 0)
+	{
+		SetupHoming(missile, projspeed);
+	}
+	else
+	{
+		missile.nextthink = time + 5;
+		missile.think = SUB_Remove;
+	}
 	missile.skin = self.skin_proj; //dumptruck_ds
 
 	if (self.mdl_proj != "") // dumptruck_ds
@@ -375,7 +381,7 @@ else if (self.style == 2)
 		EnfFireGrenade();
 		return;
 	}
-
+)
 else if (self.style == 3)
 
 	{

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -128,6 +128,8 @@ void(vector org, vector vec) LaunchLaser =
 void(vector org, vector vec) EnfLaunchSpike =
 {
 
+	local float projspeed = self.proj_speed_mod * 600;
+
 	sound_attack (self, CHAN_WEAPON, "weapons/spike2.wav", 1, ATTN_NORM);
 
 	vec = normalize(vec);
@@ -162,11 +164,18 @@ void(vector org, vector vec) EnfLaunchSpike =
 
 	setorigin (newmis, org);
 
-	newmis.velocity = vec * 600;
+	SetSpeed(newmis, vec, projspeed);
 	newmis.angles = vectoangles(newmis.velocity);
 
-	newmis.nextthink = time + 5;
-	newmis.think = SUB_Remove;
+	if (self.homing > 0)
+	{
+		SetupHoming(newmis, projspeed);
+	}
+	else
+	{
+		newmis.nextthink = time + 5;
+		newmis.think = SUB_Remove;
+	}
 	newmis.touch = superspike_touch;
 };
 

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -111,7 +111,7 @@ void(vector org, vector vec) LaunchLaser =
 
 	setorigin (newmis, org);
 
-	newmis.velocity = vec * projspeed;
+	SetSpeed(newmis, vec, projspeed);
 	newmis.angles = vectoangles(newmis.velocity);
 	if (self.homing > 0)
 	{

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -844,6 +844,11 @@ void() monster_enforcer =
 
 	setsize (self, '-16 -16 -24', '16 16 40');
 
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
+
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 80;
 

--- a/enforcer.qc
+++ b/enforcer.qc
@@ -227,7 +227,7 @@ EnfRocket //dumptruck_ds start -- from inside qc tut http://www.insideqc.com/qct
 void() EnfRocket =
 {
 	local	entity missile;
-	local float projspeed = 900 * (self.proj_speed_mod ? self.proj_speed_mod : 1);
+	local float projspeed = 900 * self.proj_speed_mod;
 	// self.currentammo = self.ammo_rockets = self.ammo_rockets - 1; dumptruck_ds
 
 	sound_attack (self, CHAN_WEAPON, "weapons/sgun1.wav", 1, ATTN_NORM);

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -124,8 +124,6 @@
 	mdl_gib1(string) : "Path to custom 1st gib model"
 	mdl_gib2(string) : "Path to custom 2nd gib model"
 	mdl_gib3(string) : "Path to custom 3rd gib model"
-	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
-	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 ]
 @baseclass = CustomMdlsWizSham
 [
@@ -662,6 +660,7 @@ The behavior of an item_key_custom should be as the player expects (based on the
 	]
 	infight_mode(Choices) =
 	[
+		-1 : "Never infight"
 		0 : "Default behavior, only with different classnames"
 		1 : "Infight with monsters with the same classname but a different mdl_body"
 		2 : "Infight with monsters with the same classname and model but a different skin"
@@ -675,6 +674,8 @@ The behavior of an item_key_custom should be as the player expects (based on the
 	obit_name(string) : "Custom description of WHO killed the player." : : "When used with obit_method, this will set part of the text for a custom obituary. e.g. a Super Soldier! Using the examples here, the obituary would read: Player was eviscerated by a Super Solider!"
 	obit_method(string) : "Custom description of HOW this monster killed the player." : : "When used with obit_name, will set part of the text for a custom obituary. e.g. eviscerated - If empty, defaults to killed."
 	damage_mod(float) : "Damage multiplier (e.g. 4 = Quad damage)" : : "USE WITH CAUTION! Multiply all damage from this monster by this number (e.g. 4 = Quad damage)"
+	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
+	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 	drop_item(Choices) =
 	[
 		0 : "(Default) Disabled"

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -124,6 +124,8 @@
 	mdl_gib1(string) : "Path to custom 1st gib model"
 	mdl_gib2(string) : "Path to custom 2nd gib model"
 	mdl_gib3(string) : "Path to custom 3rd gib model"
+	homing(float) : "Multiplier for projectile homing, maximum 1" : "0"
+	proj_speed_mod(float) : "Multiplier for projectile speed" : "1"
 ]
 @baseclass = CustomMdlsWizSham
 [

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -124,8 +124,8 @@
 	mdl_gib1(string) : "Path to custom 1st gib model"
 	mdl_gib2(string) : "Path to custom 2nd gib model"
 	mdl_gib3(string) : "Path to custom 3rd gib model"
-	homing(float) : "Multiplier for projectile homing, maximum 1" : "0"
-	proj_speed_mod(float) : "Multiplier for projectile speed" : "1"
+	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
+	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 ]
 @baseclass = CustomMdlsWizSham
 [

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -676,6 +676,7 @@ The behavior of an item_key_custom should be as the player expects (based on the
 	damage_mod(float) : "Damage multiplier (e.g. 4 = Quad damage)" : : "USE WITH CAUTION! Multiply all damage from this monster by this number (e.g. 4 = Quad damage)"
 	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
 	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
+	waitmin(float) : "When set, homing factor will begin to increase after (waitmin) seconds." : "0"
 	drop_item(Choices) =
 	[
 		0 : "(Default) Disabled"

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -89,8 +89,6 @@
 	mdl_gib1(string) : "Path to custom 1st gib model"
 	mdl_gib2(string) : "Path to custom 2nd gib model"
 	mdl_gib3(string) : "Path to custom 3rd gib model"
-	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
-	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 ]
 @baseclass = CustomMdlsWizSham
 [

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -89,6 +89,8 @@
 	mdl_gib1(string) : "Path to custom 1st gib model"
 	mdl_gib2(string) : "Path to custom 2nd gib model"
 	mdl_gib3(string) : "Path to custom 3rd gib model"
+	homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
+	proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 ]
 @baseclass = CustomMdlsWizSham
 [
@@ -501,6 +503,7 @@ The 'keyname' value is used both for the pickup message and to associate the key
 ]
 	infight_mode(Choices) =
 [
+	-1 : "Never infight"
 	0 : "Default behavior, only with different classnames"
 	1 : "Infight with monsters with the same classname but a different mdl_body"
 	2 : "Infight with monsters with the same classname and model but a different skin"
@@ -514,6 +517,8 @@ skin(integer) : "Skin index (default 0)" : : "Skin index (default 0) Use this wh
 obit_name(string) : "Custom description of WHO killed the player." : "When used with obit_method, this will set part of the text for a custom obituary. e.g. a Super Soldier! Using the examples here, the obituary would read: Player was eviscerated by a Super Solider!"
 obit_method(string) : "Custom description of HOW this monster killed the player." : "When used with obit_name, will set part of the text for a custom obituary. e.g. eviscerated - If empty, defaults to killed."
 damage_mod(float) : "Damage multiplier (e.g. 4 = Quad damage)" : : "USE WITH CAUTION! Multiply all damage from this monster by this number (e.g. 4 = Quad damage)"
+homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
+proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 drop_item(Choices) =
 [
 	0 : "(Default) Disabled"

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -518,6 +518,7 @@ obit_name(string) : "Custom description of WHO killed the player." : "When used 
 obit_method(string) : "Custom description of HOW this monster killed the player." : "When used with obit_name, will set part of the text for a custom obituary. e.g. eviscerated - If empty, defaults to killed."
 damage_mod(float) : "Damage multiplier (e.g. 4 = Quad damage)" : : "USE WITH CAUTION! Multiply all damage from this monster by this number (e.g. 4 = Quad damage)"
 homing(float) : "Multiplier for projectile homing, maximum 1. Only applies to non-grenade projectiles." : "0"
+waitmin(float) : "When set, homing factor will begin to increase after (waitmin) seconds." : "0"
 proj_speed_mod(float) : "Multiplier for projectile speed. Only applies to non-grenade projectiles." : "1"
 drop_item(Choices) =
 [

--- a/hknight.qc
+++ b/hknight.qc
@@ -117,10 +117,10 @@ void(float offset) hknight_shot =
 		}
 	}
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*300;
+	newmis.velocity = vec*300*self.proj_speed_mod;
 	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
-		SetupHoming(300);
+		SetupHoming(newmis, 300*self.proj_speed_mod);
 	}
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };

--- a/hknight.qc
+++ b/hknight.qc
@@ -118,7 +118,10 @@ void(float offset) hknight_shot =
 	}
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	newmis.velocity = vec*300;
-
+	if (self.homing > 0) // If homing is off, don't bother doing any thinking
+	{
+		SetupHoming(300);
+	}
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };
 
@@ -629,6 +632,11 @@ void() monster_hell_knight =
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 250;
+
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
 
 	self.th_stand = hknight_stand1;
 	self.th_walk = hknight_walk1;

--- a/hknight.qc
+++ b/hknight.qc
@@ -117,7 +117,7 @@ void(float offset) hknight_shot =
 		}
 	}
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*300*self.proj_speed_mod;
+	SetSpeed(newmis, vec, 300*self.proj_speed_mod);
 	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
 		SetupHoming(newmis, 300*self.proj_speed_mod);

--- a/hknight.qc
+++ b/hknight.qc
@@ -117,10 +117,6 @@ void(float offset) hknight_shot =
 		}
 	}
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	if (self.homing > 0) // If homing is off, don't bother doing any thinking
-	{
-		SetupHoming(newmis, 300*self.proj_speed_mod);
-	}
 	sound_attack (self, CHAN_WEAPON, "hknight/attack1.wav", 1, ATTN_NORM);
 };
 

--- a/hknight.qc
+++ b/hknight.qc
@@ -72,7 +72,7 @@ void(float offset) hknight_shot =
 	vec = normalize (v_forward);
 	vec_z = 0 - vec_z + (random() - 0.5)*0.1;
 
-	launch_spike (org, vec);
+	launch_spike2 (org, vec, 300);
 	newmis.classname = "knightspike";
 	// setmodel (newmis, "progs/k_spike.mdl");
 	if (exploding)
@@ -117,7 +117,6 @@ void(float offset) hknight_shot =
 		}
 	}
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	SetSpeed(newmis, vec, 300*self.proj_speed_mod);
 	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
 		SetupHoming(newmis, 300*self.proj_speed_mod);

--- a/ogre.qc
+++ b/ogre.qc
@@ -167,6 +167,7 @@ void() BDW_OgreFireFlak =
 	local float flakcount;
 	local vector dir, ang;
 	local entity flak;
+	local float projspeed = 800 * (self.proj_speed_mod ? self.proj_speed_mod : 1);
 
 	flakcount = 8;
 
@@ -186,7 +187,7 @@ void() BDW_OgreFireFlak =
 	// f*cking hack...is this a v_forward problem?
 		dir_z = dir_z * -1;
 		//dir = dir*1000;
-		dir = dir*800;
+		//dir = dir*800;
 
 
 		flak = spawn();
@@ -199,9 +200,16 @@ void() BDW_OgreFireFlak =
 		flak.flags = FL_NOSELECT;
 		flak.touch = FlakTouch;
 		flak.angles = vectoangles(dir);
-		flak.velocity = dir;
-		flak.think = SUB_Remove;
-		flak.nextthink = time + 6;
+		SetSpeed(flak, dir, projspeed);
+		if (self.homing > 0)
+		{
+			SetupHoming(flak, projspeed);
+		}
+		else
+		{
+			flak.nextthink = time + 6;
+			flak.think = SUB_Remove;
+		}
 		flak.dmg = 4;
 
 		flak.spawnflags = MONSTER_FLAK_OGRE;	//this is a hack to tell FlakTouch that it came from an ogre

--- a/ogre.qc
+++ b/ogre.qc
@@ -167,7 +167,7 @@ void() BDW_OgreFireFlak =
 	local float flakcount;
 	local vector dir, ang;
 	local entity flak;
-	local float projspeed = 800 * (self.proj_speed_mod ? self.proj_speed_mod : 1);
+	local float projspeed = 800 * self.proj_speed_mod;
 
 	flakcount = 8;
 
@@ -1364,7 +1364,10 @@ void() monster_ogre =
 	// setmodel (self, "progs/ogre.mdl");
 
 	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
-
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 200;
 
@@ -1479,7 +1482,10 @@ void() monster_ogre_marksman =
 	// setmodel (self, "progs/ogre.mdl");
 
 	setsize (self, VEC_HULL2_MIN, VEC_HULL2_MAX);
-
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 200;
 

--- a/ogre.qc
+++ b/ogre.qc
@@ -741,7 +741,7 @@ void() OgreFireLavaBall =
 	vec = normalize (d - org);
 
 	// launch_spike (org, vec);
-	launch_spike (self.origin + v_right * 4 + '0 0 16', vec);
+	launch_spike2 (self.origin + v_right * 4 + '0 0 16', vec, 600);
 	self.effects = self.effects | EF_MUZZLEFLASH;
 	if (self.mdl_proj != "") // dumptruck_ds custom_mdls
 	{
@@ -764,7 +764,6 @@ void() OgreFireLavaBall =
 	if !(newmis.avelocity)
 	newmis.avelocity = '200 100 300';
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*600; // changed from 300 since this is more like a 'nade -  dumptruck_ds
 	// newmis.touch = T_MissileTouch; // rocket explosion
 	newmis.touch = OgreGrenadeExplode;
 	sound_attack (self, CHAN_AUTO, "boss1/throw.wav", 1, ATTN_NORM);

--- a/oldone2.qc
+++ b/oldone2.qc
@@ -121,7 +121,7 @@ void(vector p) shub_missile =
 	puff.think = s_explode1;
 	puff.nextthink = time;
 
-	launch_spike (org, vec); // lavaball in your face!
+	launch_spike2 (org, vec, 300); // lavaball in your face!
 	if (self.mdl_proj != "") // dumptruck_ds custom_mdls
 	{
 			setmodel (newmis, self.mdl_proj);
@@ -143,7 +143,6 @@ void(vector p) shub_missile =
 	// setmodel (newmis, "progs/lavaball.mdl");
 	newmis.avelocity = '200 100 300';
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
-	newmis.velocity = vec*300;
 	newmis.touch = T_MissileTouch; // rocket explosion
 	sound_attack (self, CHAN_WEAPON, "boss1/throw.wav", 1, ATTN_NORM);
 

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -191,7 +191,7 @@ void() ShalMissile =
 
 	dir = normalize((self.enemy.origin + '0 0 10') - self.origin);
 	dist = vlen (self.enemy.origin - self.origin);
-	flytime = dist * 0.002;
+	flytime = dist * 0.002 * (1/self.proj_speed_mod);
 	if (flytime < 0.1)
 		flytime = 0.1;
 
@@ -227,51 +227,75 @@ void() ShalMissile =
 	setsize (missile, '0 0 0', '0 0 0');
 
 	missile.origin = self.origin + '0 0 10';
+<<<<<<< HEAD
 	missile.velocity = dir * 400;
 	missile.avelocity = self.avelocity; // custom spin on projectile --dumptruck_ds
 	if !(missile.avelocity)
 	missile.avelocity = '300 300 300';
+=======
+	missile.velocity = dir * 400 * self.proj_speed_mod;
+	missile.avelocity = self.avelocity; // custom spin on projectile --dumptruck_ds
+	if !(missile.avelocity)
+		missile.avelocity = '300 300 300';
+>>>>>>> daf06e1... Add speed mod to shalrath, abstract homing logic
 	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
 		missile.homing = self.homing;
 		missile.nextthink = flytime + time;
-		missile.think = ShalHome;
+		missile.think = MissileHome;
 	}
+	if (skill == 3)
+		missile.proj_basespeed = 350 * self.proj_speed_mod;
+	else
+		missile.proj_basespeed = 250 * self.proj_speed_mod;
 	missile.enemy = self.enemy;
 	missile.touch = ShalMissileTouch;
 };
 
-void() ShalHome =
-{
-	local vector	dir, vtemp;
-	vtemp = self.enemy.origin + '0 0 10';
-	if (self.enemy.health < 1)
-	{
-		remove(self);
-		return;
-	}
-	dir = normalize(vtemp - self.origin);
-	if (self.homing < 1 && self.homing > 0) // can't do better than 100% homing
-	{
-		/*
-		This finds a vector somewhere between the vector the projectile is currently
-		travelling on and the vector that it would normally snap to for homing
+//void() ShalHome = -- moved to weapons.qc as MissileHome for general use - iLike80sRock
+//{
+//	local vector	dir, vtemp;
+//	local float speedmod;
+//	vtemp = self.enemy.origin + '0 0 10';
+//	if (self.enemy.health < 1)
+//	{
+//		remove(self);
+//		return;
+//	}
+//	dir = normalize(vtemp - self.origin);
+//	if (self.homing < 1 && self.homing > 0) // can't do better than 100% homing
+//	{
+//		/*
+//		This finds a vector somewhere between the vector the projectile is currently
+//		travelling on and the vector that it would normally snap to for homing
+//
+//		homing = .25 means it will go 25% to the new direction, but keep 75% of the
+//		original vector, resulting in a wider turning range.
+//		*/
+//		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
+//	}
+//	dprint("self.proj_speed_mod: ");
+//	dprint(ftos(self.proj_speed_mod));
+//	dprint("\n");
+//
+//	if (skill == 3)
+//		speedmod = 350 * self.proj_speed_mod;
+//	else
+//		speedmod = 250 * self.proj_speed_mod;
 
-		homing = .25 means it will go 25% to the new direction, but keep 75% of the
-		original vector, resulting in a wider turning range.
-		*/
-		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
-	}
-	if (skill == 3)
-		self.velocity = dir * 350;
-	else
-		self.velocity = dir * 250;
-	if (self.homing > 0)
-	{
-		self.nextthink = time + 0.2;
-		self.think = ShalHome;
-	}
-};
+//	dprint("speedmod: ");
+//	dprint(ftos(speedmod));
+//	dprint("\n");
+
+//	self.velocity = dir * speedmod;
+
+//	if (self.homing > 0)
+//	{
+//		self.nextthink = time + 0.2;
+//		self.think = ShalHome;
+//	}
+//};
+
 
 // void() ShalMissileTouch = --moved to misc.qc for voreball shooter --dumptruck_ds
 // {
@@ -394,6 +418,11 @@ void() monster_shalrath =
 
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 400;
+
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
 
 	if (!self.homing) // default to normal
 	{

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -182,7 +182,7 @@ ShalMissile
 ================
 */
 void() ShalMissileTouch;
-void() ShalHome;
+//void() ShalHome;
 void() ShalMissile =
 {
 	local	entity 	missile;
@@ -227,17 +227,10 @@ void() ShalMissile =
 	setsize (missile, '0 0 0', '0 0 0');
 
 	missile.origin = self.origin + '0 0 10';
-<<<<<<< HEAD
-	missile.velocity = dir * 400;
-	missile.avelocity = self.avelocity; // custom spin on projectile --dumptruck_ds
-	if !(missile.avelocity)
-	missile.avelocity = '300 300 300';
-=======
 	missile.velocity = dir * 400 * self.proj_speed_mod;
 	missile.avelocity = self.avelocity; // custom spin on projectile --dumptruck_ds
 	if !(missile.avelocity)
 		missile.avelocity = '300 300 300';
->>>>>>> daf06e1... Add speed mod to shalrath, abstract homing logic
 	if (self.homing > 0) // If homing is off, don't bother doing any thinking
 	{
 		missile.homing = self.homing;

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -182,7 +182,6 @@ ShalMissile
 ================
 */
 void() ShalMissileTouch;
-//void() ShalHome;
 void() ShalMissile =
 {
 	local	entity 	missile;
@@ -244,50 +243,6 @@ void() ShalMissile =
 	missile.enemy = self.enemy;
 	missile.touch = ShalMissileTouch;
 };
-
-//void() ShalHome = -- moved to weapons.qc as MissileHome for general use - iLike80sRock
-//{
-//	local vector	dir, vtemp;
-//	local float speedmod;
-//	vtemp = self.enemy.origin + '0 0 10';
-//	if (self.enemy.health < 1)
-//	{
-//		remove(self);
-//		return;
-//	}
-//	dir = normalize(vtemp - self.origin);
-//	if (self.homing < 1 && self.homing > 0) // can't do better than 100% homing
-//	{
-//		/*
-//		This finds a vector somewhere between the vector the projectile is currently
-//		travelling on and the vector that it would normally snap to for homing
-//
-//		homing = .25 means it will go 25% to the new direction, but keep 75% of the
-//		original vector, resulting in a wider turning range.
-//		*/
-//		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
-//	}
-//	dprint("self.proj_speed_mod: ");
-//	dprint(ftos(self.proj_speed_mod));
-//	dprint("\n");
-//
-//	if (skill == 3)
-//		speedmod = 350 * self.proj_speed_mod;
-//	else
-//		speedmod = 250 * self.proj_speed_mod;
-
-//	dprint("speedmod: ");
-//	dprint(ftos(speedmod));
-//	dprint("\n");
-
-//	self.velocity = dir * speedmod;
-
-//	if (self.homing > 0)
-//	{
-//		self.nextthink = time + 0.2;
-//		self.think = ShalHome;
-//	}
-//};
 
 
 // void() ShalMissileTouch = --moved to misc.qc for voreball shooter --dumptruck_ds

--- a/shalrath.qc
+++ b/shalrath.qc
@@ -226,7 +226,7 @@ void() ShalMissile =
 	setsize (missile, '0 0 0', '0 0 0');
 
 	missile.origin = self.origin + '0 0 10';
-	missile.velocity = dir * 400 * self.proj_speed_mod;
+	SetSpeed(missile, dir, 400 * self.proj_speed_mod);
 	missile.avelocity = self.avelocity; // custom spin on projectile --dumptruck_ds
 	if !(missile.avelocity)
 		missile.avelocity = '300 300 300';

--- a/soldier.qc
+++ b/soldier.qc
@@ -129,7 +129,7 @@ void() MonFireSpike =
     dir = normalize (self.enemy.origin - self.origin);
 		makevectors (self.angles); //thanks Voidforce -- dumptruck_ds
 
-    launch_spike (self.origin + v_forward * 30 + v_right * 5 + '0 0 12', dir);  //dumptruck_ds
+    launch_spike2 (self.origin + v_forward * 30 + v_right * 5 + '0 0 12', dir, (1000 * self.proj_speed_mod));  //dumptruck_ds
     // launch_spike (self.origin + '0 0 16', dir);
 
     newmis.touch = superspike_touch;

--- a/soldier.qc
+++ b/soldier.qc
@@ -129,7 +129,7 @@ void() MonFireSpike =
     dir = normalize (self.enemy.origin - self.origin);
 		makevectors (self.angles); //thanks Voidforce -- dumptruck_ds
 
-    launch_spike2 (self.origin + v_forward * 30 + v_right * 5 + '0 0 12', dir, (1000 * self.proj_speed_mod));  //dumptruck_ds
+    launch_spike (self.origin + v_forward * 30 + v_right * 5 + '0 0 12', dir);  //dumptruck_ds
     // launch_spike (self.origin + '0 0 16', dir);
 
     newmis.touch = superspike_touch;

--- a/soldier.qc
+++ b/soldier.qc
@@ -606,6 +606,11 @@ void() monster_army =
 
 	setsize (self, '-16 -16 -24', '16 16 40');
 
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
+
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 30;
 

--- a/weapons.qc
+++ b/weapons.qc
@@ -961,8 +961,8 @@ launch_spike
 Used for both the player and the ogre
 ===============
 */
-void(vector org, vector dir) launch_spike =
-{
+
+void(vector org, vector dir, float speed) launch_spike2 = {
 	newmis = spawn ();
 	newmis.owner = self;
 	newmis.movetype = MOVETYPE_FLYMISSILE;
@@ -972,13 +972,23 @@ void(vector org, vector dir) launch_spike =
 
 	newmis.touch = spike_touch;
 	newmis.classname = "spike";
-	newmis.think = SUB_Remove;
-	newmis.nextthink = time + 6;
+	if (self.homing > 0)
+	{
+		SetupHoming(newmis, speed);
+	}
+	else
+	{
+		newmis.think = SUB_Remove;
+		newmis.nextthink = time + 6;
+	}
 	setmodel (newmis, "progs/spike.mdl");
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	setorigin (newmis, org);
 
-	newmis.velocity = dir * 1000;
+	newmis.velocity = dir * speed;
+};
+void(vector org, vector dir) launch_spike = {
+	launch_spike2(org,dir,1000);
 };
 
 void() W_FireSuperSpikes =
@@ -1730,7 +1740,7 @@ void() MissileHome =
 	}
 	if (!self.avelocity)
 		self.angles = vectoangles(dir);
-	self.velocity = dir * self.proj_basespeed;
+	SetSpeed(self, dir, self.proj_basespeed);
 
 	if (self.homing > 0)
 	{

--- a/weapons.qc
+++ b/weapons.qc
@@ -649,7 +649,7 @@ void() W_GruntRocket =
 // set missile speed  -- dumptruck_ds below
 
 	missile.velocity = normalize(self.enemy.origin - self.origin);
-  missile.velocity = missile.velocity * 900;
+  SetSpeed(missile, missile.velocity, 900*self.proj_speed_mod);
   missile.angles = vectoangles(missile.velocity);
   missile.touch = T_GruntMisTouch;
 
@@ -661,8 +661,14 @@ void() W_GruntRocket =
 	// missile.touch = T_MissileTouch;
 
 // set missile duration
-	missile.nextthink = time + 5;
-	missile.think = SUB_Remove;
+	if (self.homing)
+	{
+		SetupHoming(missile, 900 * self.proj_speed_mod);
+	}
+	else {
+		missile.nextthink = time + 5;
+		missile.think = SUB_Remove;
+	}
 	if (self.mdl_proj != "") // dumptruck_ds
 	{
 			setmodel (missile, self.mdl_proj);

--- a/weapons.qc
+++ b/weapons.qc
@@ -661,7 +661,7 @@ void() W_GruntRocket =
 	// missile.touch = T_MissileTouch;
 
 // set missile duration
-	if (self.homing)
+	if (self.homing > 0)
 	{
 		SetupHoming(missile, 900 * self.proj_speed_mod);
 	}

--- a/weapons.qc
+++ b/weapons.qc
@@ -6,7 +6,7 @@ void(entity bomb, entity attacker, float rad, entity ignore) T_RadiusDamage;
 void(vector org, vector vel, float damage) SpawnBlood;
 void() SuperDamageSound;
 void() create_mobot; //dumptruck_ds mobot.qc
-
+void(entity mis, float speed) SetupHoming;
 
 // called by worldspawn
 void() W_Precache =

--- a/weapons.qc
+++ b/weapons.qc
@@ -991,7 +991,7 @@ void(vector org, vector dir, float speed) launch_spike2 = {
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	setorigin (newmis, org);
 
-	newmis.velocity = dir * speed * self.proj_speed_mod;
+	newmis.velocity = dir * speed * (self.proj_speed_mod ? self.proj_speed_mod : 1);
 };
 void(vector org, vector dir) launch_spike = {
 	launch_spike2(org,dir,1000);

--- a/weapons.qc
+++ b/weapons.qc
@@ -1752,13 +1752,13 @@ void() MissileHome =
 	{
 		if (self.homing < 1 && self.attack_finished && self.attack_finished < time )
 		{
-			dprint("incrementing homing | ");
-			dprint("old: ");
-			dprint(ftos(self.homing));
-			dprint(" | new: ");
+			//dprint("incrementing homing | ");
+			//dprint("old: ");
+			//dprint(ftos(self.homing));
+			//dprint(" | new: ");
 			self.homing = self.homing + 0.005;
-			dprint(ftos(self.homing));
-			dprint("\n");
+			//dprint(ftos(self.homing));
+			//dprint("\n");
 		}
 		self.nextthink = time + 0.2;
 		self.think = MissileHome;
@@ -1794,6 +1794,6 @@ void(entity mis, float speed) SetupHoming =
 	mis.think = MissileHome;
 	if (self.waitmin > 0)
 	{
-		mis.attack_finished = time + self.waitmin; // store start time
+		mis.attack_finished = time + self.waitmin; // store time to start increasing
 	} 
 };

--- a/weapons.qc
+++ b/weapons.qc
@@ -991,7 +991,7 @@ void(vector org, vector dir, float speed) launch_spike2 = {
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	setorigin (newmis, org);
 
-	newmis.velocity = dir * speed;
+	newmis.velocity = dir * speed * self.proj_speed_mod;
 };
 void(vector org, vector dir) launch_spike = {
 	launch_spike2(org,dir,1000);

--- a/weapons.qc
+++ b/weapons.qc
@@ -1039,21 +1039,16 @@ void() spike_touch =
 	}
 	else
 	{
-		if (self.owner.snd_hit){
-				sound_hit (self, CHAN_WEAPON, self.owner.snd_hit, 1, ATTN_STATIC); //dumptruck_ds
-		}
-		WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
 
-		if (self.classname == "wizspike")
-			if (self.owner.snd_hit)
-			{
-					sound_hit (self, CHAN_WEAPON, self.owner.snd_hit, 1, ATTN_STATIC); //dumptruck_ds
-					WriteByte(MSG_BROADCAST, TE_GUNSHOT);
-			}
-			else
-			{
-				WriteByte (MSG_BROADCAST, TE_WIZSPIKE);
-			}
+		WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
+		if (self.snd_hit)
+		{
+				sound (self, CHAN_WEAPON, self.snd_hit, 1, ATTN_STATIC); //dumptruck_ds
+				WriteByte(MSG_BROADCAST, TE_GUNSHOT);
+		}
+
+		else if (self.classname == "wizspike")
+			WriteByte (MSG_BROADCAST, TE_WIZSPIKE);
 		else if (self.classname == "knightspike")
 			WriteByte (MSG_BROADCAST, TE_KNIGHTSPIKE);
 		else
@@ -1736,10 +1731,22 @@ void() MissileHome =
 void(entity mis, float speed) SetupHoming =
 {
 	local	vector	dir;
-	local	float	dist, flytime;
+	local	float	dist, flytime, speedmod;
+	if (self.proj_speed_mod > 1)
+	{
+		speedmod = 1/self.proj_speed_mod;
+	}
+	else if (speed > 250)
+	{
+		speedmod = 1 / (speed / 250);
+	}
+	else
+	{
+		speedmod = 1;
+	}
 	dir = normalize((self.enemy.origin + '0 0 10') - self.origin);
 	dist = vlen (self.enemy.origin - self.origin);
-	flytime = dist * 0.002 * (1/self.proj_speed_mod);
+	flytime = dist * 0.002 * speedmod;
 	if (flytime < 0.1)
 		flytime = 0.1;
 

--- a/weapons.qc
+++ b/weapons.qc
@@ -991,7 +991,7 @@ void(vector org, vector dir, float speed) launch_spike2 = {
 	setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
 	setorigin (newmis, org);
 
-	newmis.velocity = dir * speed * (self.proj_speed_mod ? self.proj_speed_mod : 1);
+	SetSpeed(newmis, dir, speed * (self.proj_speed_mod ? self.proj_speed_mod : 1));
 };
 void(vector org, vector dir) launch_spike = {
 	launch_spike2(org,dir,1000);

--- a/weapons.qc
+++ b/weapons.qc
@@ -1733,7 +1733,7 @@ void() MissileHome =
 	}
 };
 
-void(float speed) SetupHoming =
+void(entity mis, float speed) SetupHoming =
 {
 	local	vector	dir;
 	local	float	dist, flytime;
@@ -1743,9 +1743,9 @@ void(float speed) SetupHoming =
 	if (flytime < 0.1)
 		flytime = 0.1;
 
-	newmis.enemy = self.enemy;
-	newmis.proj_basespeed = speed;
-	newmis.homing = self.homing;
-	newmis.nextthink = flytime + time;
-	newmis.think = MissileHome;
+	mis.enemy = self.enemy;
+	mis.proj_basespeed = speed;
+	mis.homing = self.homing;
+	mis.nextthink = flytime + time;
+	mis.think = MissileHome;
 };

--- a/weapons.qc
+++ b/weapons.qc
@@ -8,6 +8,17 @@ void() SuperDamageSound;
 void() create_mobot; //dumptruck_ds mobot.qc
 void(entity mis, float speed) SetupHoming;
 
+void(entity mis, vector dir, float speed) SetSpeed =
+{
+	if (cvar("sv_maxvelocity") > speed)
+	{
+		mis.velocity = dir * speed;
+	}
+	else {
+		mis.velocity = dir * cvar("sv_maxvelocity");
+	}
+};
+
 // called by worldspawn
 void() W_Precache =
 {

--- a/weapons.qc
+++ b/weapons.qc
@@ -1699,3 +1699,53 @@ void() SuperDamageSound =
 	}
 	return;
 };
+
+void() MissileHome =
+{
+	local vector	dir, vtemp;
+	vtemp = self.enemy.origin + '0 0 10';
+
+	if (self.enemy.health < 1)
+	{
+		remove(self);
+		return;
+	}
+	dir = normalize(vtemp - self.origin);
+	if (self.homing < 1 && self.homing > 0) // can't do better than 100% homing
+	{
+		/*
+		This finds a vector somewhere between the vector the projectile is currently
+		travelling on and the vector that it would normally snap to for homing
+
+		homing = .25 means it will go 25% to the new direction, but keep 75% of the
+		original vector, resulting in a wider turning range.
+		*/
+		dir = normalize((dir * self.homing) + normalize(self.velocity * (1 - self.homing)));
+	}
+	if (!self.avelocity)
+		self.angles = vectoangles(dir);
+	self.velocity = dir * self.proj_basespeed;
+
+	if (self.homing > 0)
+	{
+		self.nextthink = time + 0.2;
+		self.think = MissileHome;
+	}
+};
+
+void(float speed) SetupHoming =
+{
+	local	vector	dir;
+	local	float	dist, flytime;
+	dir = normalize((self.enemy.origin + '0 0 10') - self.origin);
+	dist = vlen (self.enemy.origin - self.origin);
+	flytime = dist * 0.002 * (1/self.proj_speed_mod);
+	if (flytime < 0.1)
+		flytime = 0.1;
+
+	newmis.enemy = self.enemy;
+	newmis.proj_basespeed = speed;
+	newmis.homing = self.homing;
+	newmis.nextthink = flytime + time;
+	newmis.think = MissileHome;
+};

--- a/weapons.qc
+++ b/weapons.qc
@@ -1750,6 +1750,16 @@ void() MissileHome =
 
 	if (self.homing > 0)
 	{
+		if (self.homing < 1 && self.attack_finished && self.attack_finished < time )
+		{
+			dprint("incrementing homing | ");
+			dprint("old: ");
+			dprint(ftos(self.homing));
+			dprint(" | new: ");
+			self.homing = self.homing + 0.005;
+			dprint(ftos(self.homing));
+			dprint("\n");
+		}
 		self.nextthink = time + 0.2;
 		self.think = MissileHome;
 	}
@@ -1782,4 +1792,8 @@ void(entity mis, float speed) SetupHoming =
 	mis.homing = self.homing;
 	mis.nextthink = flytime + time;
 	mis.think = MissileHome;
+	if (self.waitmin > 0)
+	{
+		mis.attack_finished = time + self.waitmin; // store start time
+	} 
 };

--- a/wizard.qc
+++ b/wizard.qc
@@ -200,6 +200,8 @@ void() Wiz_FastFire =
 {
 	local vector		vec;
 	local vector		dst;
+	local entity oldself;
+	local float projspeed = self.owner.proj_speed_mod * 600;
 
 	if (self.owner.health > 0)
 	{
@@ -211,7 +213,7 @@ void() Wiz_FastFire =
 		vec = normalize(dst - self.origin);
 		// sound_attack (self, CHAN_WEAPON, "wizard/wattack.wav", 1, ATTN_NORM);
 		launch_spike (self.origin, vec);
-		newmis.velocity = vec*600;
+		newmis.velocity = vec*projspeed;
 		newmis.owner = self.owner;
 		newmis.classname = "wizspike";
 		if (self.owner.projexpl)
@@ -219,9 +221,17 @@ void() Wiz_FastFire =
 			// dprint("spawning exploding wizard proj from fastfire\n");
 			newmis.touch = T_WizardMisTouch;
 		}
+		if (self.owner.homing)
+		{
+			oldself = self;
+			self = self.owner;
+			SetupHoming(newmis, projspeed);
+			self = oldself;
+		}
 		setmodel(newmis, self.owner.mdl_proj);
 		newmis.skin = self.owner.skin_proj;
 		setsize (newmis, VEC_ORIGIN, VEC_ORIGIN);
+
 	}
 
 	remove (self);
@@ -243,22 +253,12 @@ void() Wiz_StartFast =
 	setorigin (missile, self.origin + '0 0 30' + v_forward*14 + v_right*14);
 	missile.enemy = self.enemy;
 	missile.nextthink = time + 0.8;
-	if (self.projexpl)
-	{
-		// dprint("spawning exploding wizard proj from startfast 1\n");
-		missile.touch = T_WizardMisTouch;
-	}
 	missile.think = Wiz_FastFire;
 	missile.movedir = v_right;
 
 	missile = spawn ();
 	missile.owner = self;
 	missile.nextthink = time + 1;
-	if (self.projexpl)
-	{
-		// dprint("spawning exploding wizard proj from startfast 2\n");
-		missile.touch = T_WizardMisTouch;
-	}
 	setsize (missile, '0 0 0', '0 0 0');
 	setorigin (missile, self.origin + '0 0 30' + v_forward*14 + v_right* -14);
 	missile.enemy = self.enemy;

--- a/wizard.qc
+++ b/wizard.qc
@@ -530,6 +530,11 @@ void() monster_wizard =
 
 	setsize (self, '-16 -16 -24', '16 16 40');
 
+	if (!self.proj_speed_mod)
+	{
+		self.proj_speed_mod = 1;
+	}
+
 	if (!self.health) //thanks RennyC -- dumptruck_ds
 	self.health = 80;
 

--- a/wizard.qc
+++ b/wizard.qc
@@ -200,7 +200,6 @@ void() Wiz_FastFire =
 {
 	local vector		vec;
 	local vector		dst;
-	local entity oldself;
 	local float projspeed = self.owner.proj_speed_mod * 600;
 
 	if (self.owner.health > 0)

--- a/wizard.qc
+++ b/wizard.qc
@@ -213,7 +213,7 @@ void() Wiz_FastFire =
 		vec = normalize(dst - self.origin);
 		// sound_attack (self, CHAN_WEAPON, "wizard/wattack.wav", 1, ATTN_NORM);
 		launch_spike (self.origin, vec);
-		newmis.velocity = vec*projspeed;
+		SetSpeed(newmis, vec, projspeed);
 		newmis.owner = self.owner;
 		newmis.classname = "wizspike";
 		if (self.owner.projexpl)

--- a/wizard.qc
+++ b/wizard.qc
@@ -212,21 +212,13 @@ void() Wiz_FastFire =
 
 		vec = normalize(dst - self.origin);
 		// sound_attack (self, CHAN_WEAPON, "wizard/wattack.wav", 1, ATTN_NORM);
-		launch_spike (self.origin, vec);
-		SetSpeed(newmis, vec, projspeed);
+		launch_spike2 (self.origin, vec, projspeed);
 		newmis.owner = self.owner;
 		newmis.classname = "wizspike";
 		if (self.owner.projexpl)
 		{
 			// dprint("spawning exploding wizard proj from fastfire\n");
 			newmis.touch = T_WizardMisTouch;
-		}
-		if (self.owner.homing)
-		{
-			oldself = self;
-			self = self.owner;
-			SetupHoming(newmis, projspeed);
-			self = oldself;
 		}
 		setmodel(newmis, self.owner.mdl_proj);
 		newmis.skin = self.owner.skin_proj;


### PR DESCRIPTION
Adds projectile speed and homing modifiers to all regular monster projectiles.

Monsters / styles completed:
```
x army style 1 (rocket)
x army style 3 (laser)
x army style 4 (nails)
x enforcer style 0
x enforcer style 3
x HKnight
x Vore
x Wizard
x boss2
x boss
x ogre style 4
x ogre style 2
x ogre style 1
x oldone2
x enforcer style 1
```

Additionally adds:

- new infighting -1 mode where the monster will not respond to any non-player attacks
- Increasing homing factor - set `waitmin` on a monster and their projectiles' homing factors will begin to increase by .05 every think after that many seconds

Closes #127 