### PR TITLE
Fix wizard projectiles

### DIFF
--- a/weapons.qc
+++ b/weapons.qc
@@ -1068,9 +1068,9 @@ void() spike_touch =
 	{
 
 		WriteByte (MSG_BROADCAST, SVC_TEMPENTITY);
-		if (self.snd_hit)
+		if (self.owner.snd_hit)
 		{
-				sound (self, CHAN_WEAPON, self.snd_hit, 1, ATTN_STATIC); //dumptruck_ds
+				sound (self, CHAN_WEAPON, self.owner.snd_hit, 1, ATTN_STATIC); //dumptruck_ds
 				WriteByte(MSG_BROADCAST, TE_GUNSHOT);
 		}
 

--- a/wizard.qc
+++ b/wizard.qc
@@ -212,13 +212,21 @@ void() Wiz_FastFire =
 
 		vec = normalize(dst - self.origin);
 		// sound_attack (self, CHAN_WEAPON, "wizard/wattack.wav", 1, ATTN_NORM);
-		launch_spike2 (self.origin, vec, projspeed);
+		launch_spike (self.origin, vec);
+		SetSpeed(newmis, vec, projspeed);
 		newmis.owner = self.owner;
 		newmis.classname = "wizspike";
 		if (self.owner.projexpl)
 		{
 			// dprint("spawning exploding wizard proj from fastfire\n");
 			newmis.touch = T_WizardMisTouch;
+		}
+		if (self.owner.homing)
+		{
+			oldself = self;
+			self = self.owner;
+			SetupHoming(newmis, projspeed);
+			self = oldself;
 		}
 		setmodel(newmis, self.owner.mdl_proj);
 		newmis.skin = self.owner.skin_proj;

--- a/wizard.qc
+++ b/wizard.qc
@@ -200,6 +200,7 @@ void() Wiz_FastFire =
 {
 	local vector		vec;
 	local vector		dst;
+	local entity oldself;
 	local float projspeed = self.owner.proj_speed_mod * 600;
 
 	if (self.owner.health > 0)


### PR DESCRIPTION
The wizard does something a little different when spawning projectiles so the way the nice clean common method sets everything up doesn't work. I didn't realize that and cleaned it up. This puts back the older code that did work.