### PR TITLE
Minor unmerged features

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -1033,3 +1033,26 @@ void(entity client, float density, vector color, float spd) csf_fade;
 void(entity client, float density, vector color) csf_set;
 
 .float fade_amt;
+
+// worldspawn default mdls
+.string h_vial_mdl;
+.string h_25_mdl;
+.string h_15_mdl;
+.string h_mega_mdl;
+
+.string s_sm_mdl;
+.string s_lg_mdl;
+
+.string n_sm_mdl;
+.string n_lg_mdl;
+
+.string r_sm_mdl;
+.string r_lg_mdl;
+
+.string c_sm_mdl;
+.string c_lg_mdl;
+
+.string a_shr_mdl;
+.string a_grn_mdl;
+.string a_ylw_mdl;
+.string a_red_mdl;

--- a/defs.qc
+++ b/defs.qc
@@ -1056,3 +1056,5 @@ void(entity client, float density, vector color) csf_set;
 .string a_grn_mdl;
 .string a_ylw_mdl;
 .string a_red_mdl;
+
+.entity infight_activator;

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -265,6 +265,13 @@ Can set Berserk to 1 to skip most pain animations.
 Can only use default health, models and sounds.
 "
 [
+	spawnflags(flags) =
+		[
+		1: "Reset after completion" : 0
+		2: "Don't spawn angry" : 0
+		4: "Don't add to count" : 0
+		32: "Silent spawn" : 0
+		]
 style(Choices) =
 [
 	1 : "Dog (Default)"

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -2288,10 +2288,17 @@ Check each field's description for more details.
 		2 : "Episode 2" : 0
 		4 : "Episode 3" : 0
 		8 : "Episode 4" : 0
+		16 : "Reverse functionality" : 0
 	]
 ]
 
-@SolidClass base(Appearflags) = func_bossgate : "Boss gate" []
+@SolidClass base(Appearflags) = func_bossgate : "Boss gate"
+[
+	spawnflags(Flags) =
+	[
+		16 : "Reverse functionality" : 0
+	]
+]
 
 //
 // triggers

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -2510,7 +2510,10 @@ If you want to make them angry at each other instantly, you can set the spawnfla
 [
 	target(target_destination) : "The monster who will get angry."
 	target2(target_destination) : "Who target will get angry at."
-	spawnflags(flags) = [ 1: "Mutual hate" : 0 ]
+	spawnflags(flags) = [ 
+		1: "Mutual hate" : 0
+		2: "Keep player as activator" : 0
+		 ]
 ]
 
 @PointClass base(Appearflags, Targetname) = trigger_changetarget : "Changes the target field on an entity.

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -2234,7 +2234,19 @@ spawnflags(Flags) =
 ]
 @PointClass size(16 16 16) = misc_noisemaker : "Debug entity: continuously plays enforcer sounds" []
 @PointClass size(16 16 16) = viewthing : "Debug entity: fake player model" []
+@PointClass base(Appearflags, Targetname, TriggerWait) = misc_infight : "Makes 'target' monster angry at 'target2'.
 
+By default, the infighting doesn't start mutually, that is, 'target2' monster will only get mad back at 'target' after it's been attacked.
+
+If you want to make them angry at each other instantly, you can set the spawnflag 'Mutual hate'."
+[
+	target(target_destination) : "The monster who will get angry."
+	target2(target_destination) : "Who target will get angry at."
+	spawnflags(flags) = [ 
+		1: "Mutual hate" : 0
+		2: "Keep player as activator" : 0
+		 ]
+]
 @PointClass base(Appearflags, Targetname) = trigger_changetarget : "Changes the target field on an entity.
 
 'message' is the value of the new target.

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -103,10 +103,10 @@
 [
 	mdl_body(string) : "Path to custom body model"
 ]
-@baseclass = CustomMdlsSkin
+@baseclass studio() = CustomMdlsSkin
 [
 skin(integer) : "Skin index (default 0)"
-mdl_body(string) : "Path to custom body model"
+mdl_body(studio) : "Path to custom body model"
 ]
 @baseclass = CustomMdlsAmmo
 [
@@ -279,8 +279,7 @@ state(choices) =
 	cnt(integer): "Page number"
 ]
 
-@PointClass base(Targetname, Appearflags) color(255 0 128) size(32 32 32) = target_autosave :
-"Saves the game when triggered by a player. Never appears in multiplayer.
+@PointClass base(Targetname, Appearflags) color(255 0 128) size(32 32 32) = target_autosave : "Saves the game when triggered by a player. Never appears in multiplayer.
 the bprint tends to stomp any other prints on screen in most quake clients, so use a delayed trigger_relay if you fire this from an important pickup/trigger_counter/something else that puts text on screen more important than the autosave blurb."
 [
 	message(string) : "Change save filename" : "auto"
@@ -408,20 +407,12 @@ item_health_vial : "Small vial of health (default 5)"
 @BaseClass base(NonRespawnableItem) size(-16 -16 -24, 16 16 32) =
 	Key []
 // @PointClass base(Key) model({ "path": ":progs/w_s_key.mdl" }) =
-@PointClass base(Key, CustomMdlsSkin) model(
-	{{
-		mdl_body -> {"path" : mdl_body, "skin" : skin}, {"path": ":progs/w_s_key.mdl" , "skin" : skin}
-	}}
-) = item_key1 : "Silver key" [
+@PointClass base(Key, CustomMdlsSkin) studio("progs/w_s_key.mdl") = item_key1 : "Silver key" [
 	keyname(string) : "Custom name for the key when picked up, e.g. 'silver eyekey'"
 ]
 
 // @PointClass base(Key) model({ "path": ":progs/w_g_key.mdl" }) =
-@PointClass base(Key, CustomMdlsSkin) model(
-	{{
-		mdl_body -> {"path" : mdl_body, "skin" : skin}, {"path": ":progs/w_g_key.mdl" , "skin" : skin}
-	}}
-) = item_key2 : "Gold key" [
+@PointClass base(Key, CustomMdlsSkin) studio("progs/w_s_key.mdl") = item_key2 : "Gold key" [
 	keyname(string) : "Custom name for the key when picked up, e.g. 'gold eyekey'"
 ]
 
@@ -468,7 +459,7 @@ The 'keyname' value is used both for the pickup message and to associate the key
 //axe not used in this version
 //@PointClass base(Weapon) studio("progs/g_axe.mdl") =
 //	weapon_axe : "Axe" []
-@PointClass base(Weapon) studio({ "path": ":progs/g_shotgu.mdl" }) =
+@PointClass base(Weapon) studio("progs/g_shotgu.mdl") =
 	weapon_shotgun : "Shotgun"[]
 @PointClass base(Weapon) studio("progs/g_shot.mdl") =
 	weapon_supershotgun : "Double-barrelled shotgun" []
@@ -1880,8 +1871,7 @@ If the target entity changes its default behavior when 'targetname' is set (such
 	delay(integer) : "Delay before trigger"
 	message(string) : "Message"
 ]
-@SolidClass base(Appearflags, Targetname) = func_train :
-"Trains are moving platforms that players, monsters and items can ride on. The target's origin specifies the min point of the train at each corner. The train spawns at the first target it is pointing at.
+@SolidClass base(Appearflags, Targetname) = func_train : "Trains are moving platforms that players, monsters and items can ride on. The target's origin specifies the min point of the train at each corner. The train spawns at the first target it is pointing at.
 Use path_corner as targets.
 If given a targetname, it'll only start moving after triggered.
 path_corners with a 'wait -1' value will stop the train. Trigger the func_train again to resume its path.
@@ -1920,8 +1910,7 @@ The flags above are mutually exclusive and will cause an objerror when selected 
 ]
 
 
-@PointClass base(Targetname) studio({ "path" : mdl, "skin" : skin, "frame" : first_frame}) = misc_modeltrain :
-"Trains are moving platforms that players can ride. The target's origin specifies the min point of the train at each corner. The train spawns at the first target it is pointing at.
+@PointClass base(Targetname) studio(mdl) = misc_modeltrain :"Trains are moving platforms that players can ride. The target's origin specifies the min point of the train at each corner. The train spawns at the first target it is pointing at.
 Use path_corner as targets.
 If given a targetname, it'll only start moving after triggered.
 path_corners with a 'wait -1' value will stop the train. Trigger the func_train again to resume its path.
@@ -1984,8 +1973,7 @@ Spawnflags:
 	]
 ]
 
-@PointClass base(Appearflags, Targetname) color(0 255 255) size(16 16 16) = path_corner :
-"Waypoint for trains and walking monsters.
+@PointClass base(Appearflags, Targetname) color(0 255 255) size(16 16 16) = path_corner : "Waypoint for trains and walking monsters.
 Check each field's description for more details.
 "
 [
@@ -2299,8 +2287,7 @@ Acts as a smoothly blending portal between two zones of different fog. Sets the 
 	angle(integer) : "Axis of motion of blend (points toward end values)"
 ]
 
-@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fog :
-"Trigger: Sets a fog.
+@SolidClass base(Appearflags, Targetname, FogShift, TriggerWait) = trigger_fog : "Trigger: Sets a fog.
 Smoothly blends client's currently applied fog to this value over time.
 
 - both standard fog and skyfog can be changed at the same time. If you want one of them to not be changed, just set its density to 0 (or keep undeclared). To clear them, set density to -1.
@@ -2313,8 +2300,7 @@ Smoothly blends client's currently applied fog to this value over time.
 	delay(string) : "Pause before starting blend"
 ]
 
-@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend :
-"Target: Fog Blend
+@PointClass base(Appearflags, Targetname, Target, FogShift) color(128 128 50) = target_fogblend : "Target: Fog Blend
 Activator's fog will toggle between fog_color/fog_density and fog_color2/fog_density2 values, smoothly blending it over time.
 If you check the 'one-way' spawnflag, it'll only blend over to fog_color2/fog_density2 - unless you check the 'reverse' flag as well, which will make it blend only to fog_color/fog_density.
 Checking 'All clients' will affect all connected players.
@@ -2334,8 +2320,7 @@ Checking 'All clients' will affect all connected players.
 ]
 
 
-@SolidClass base(Appearflags, Targetname, TriggerWait) = trigger_textstory :
-"Trigger to show long centerprint texts. Message remains on screen while player is inside the trigger volume. Can have custom sounds, or be made silent.
+@SolidClass base(Appearflags, Targetname, TriggerWait) = trigger_textstory : "Trigger to show long centerprint texts. Message remains on screen while player is inside the trigger volume. Can have custom sounds, or be made silent.
 
 Horizontal space is limited to 40 characters, so you must place linefeeds (\n) into your text.
 
@@ -2355,8 +2340,7 @@ You can set it to be show the message only when the player is facing a certain a
 	]
 ]
 
-@PointClass base(Appearflags, Targetname, Message) = target_textstory :
-"Trigger to show long centerprint texts. Message remains on screen for the duration of 'wait'. Can have custom sounds, or be made silent.
+@PointClass base(Appearflags, Targetname, Message) = target_textstory : "Trigger to show long centerprint texts. Message remains on screen for the duration of 'wait'. Can have custom sounds, or be made silent.
 
 Horizontal space is limited to 40 characters, so you must place linefeeds (\n) into your text.
 
@@ -2952,7 +2936,7 @@ spawnflags(flags) =
 		2048 : "2048"
 	]
 	_shadowlightradius(float) : "Sets the radius." : "300"
-	_color(color) : "Light color" : "1.0 1.0 1.0"
+	_color(color255) : "Light color" : "1.0 1.0 1.0"
 	_shadowlightconeangle(float) : "Sets the outer cone angle if this light is a spot light." : "45"
 	_shadowlightstyle(choices) : "Appearance" : "0" = [
 		0 : "Normal"

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -214,6 +214,13 @@ state(choices) =
 
 //____TW_EDIT____
 @PointClass color(206 18 18) base(OneTarget, OneTargetname, Berserk, Appearflags) = func_monster_spawner : "Spawns monsters to a targeted info_monster_spawnpoint (make sure both entities are close together or overlapping). Choose Style via dropdown. Style 2 set to 1 overrides Style and chooses a random monster. Default time between spawns is 5 seconds. Setting Berserk to 1 skips most pain animations. Can only use default health, models and sounds." [
+  spawnflags(flags) =
+		[
+		1: "Reset after completion" : 0
+		2: "Don't spawn angry" : 0
+		4: "Don't add to count" : 0
+		32: "Silent spawn" : 0
+		]
   style(Choices) = [
     1 : "Dog (Default)"
 	2 : "Grunt"

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -2064,10 +2064,17 @@ spawnflags(Flags) =
 		2 : "Episode 2" : 0
 		4 : "Episode 3" : 0
 		8 : "Episode 4" : 0
+		16 : "Reverse functionality" : 0
 	]
 ]
 
-@SolidClass = func_bossgate : "Boss gate" []
+@SolidClass = func_bossgate : "Boss gate"
+[
+	spawnflags(Flags) =
+	[
+		16 : "Reverse functionality" : 0
+	]
+]
 
 //
 // triggers

--- a/items.qc
+++ b/items.qc
@@ -244,8 +244,14 @@ void() item_health =
 
 	self.touch = health_touch;
 
+	
+
 	if (self.spawnflags & H_ROTTEN)
 	{
+		if (!self.mdl_body && world.h_15_mdl)
+		{
+			self.mdl_body = world.h_15_mdl;
+		}
 		// precache_model("maps/b_bh10.bsp"); // dumptruck_ds custom health models and sounds START
 		if (world.style)
 			{
@@ -275,6 +281,10 @@ void() item_health =
 	else
 	if (self.spawnflags & H_MEGA)
 	{
+		if (!self.mdl_body && world.h_mega_mdl)
+		{
+			self.mdl_body = world.h_mega_mdl;
+		}
 		// precache_model("maps/b_bh100.bsp");
 		if (world.style)
 			{
@@ -301,6 +311,10 @@ void() item_health =
 	}
 	else
 	{
+		if (!self.mdl_body && world.h_25_mdl)
+		{
+			self.mdl_body = world.h_25_mdl;
+		}
 		if (world.style)
 			{
 				precache_body_model ("progs/h_mdls/m_h25.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -331,6 +345,11 @@ void() item_health_vial =
 		return;
 
 	self.touch = health_touch;
+
+	if (!self.mdl_body && world.h_vial_mdl)
+	{
+	  self.mdl_body = world.h_vial_mdl;
+	}
 
 	precache_body_model ("progs/h_mdls/pd_vial.mdl"); // model from Hexen 2 -- dumptruck_ds
 	body_model("progs/h_mdls/pd_vial.mdl");
@@ -574,6 +593,11 @@ void() item_armor_shard =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
+	if (!self.mdl_body && world.a_shr_mdl)
+	{
+	  self.mdl_body = world.a_shr_mdl;
+	}
+
 	self.touch = shard_touch;
 	// precache_model ("progs/armor.mdl"); // dumptruck_ds custom models and sounds START
 	precache_body_model ("progs/armshr.mdl");
@@ -590,6 +614,11 @@ void() item_armor1 =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
+
+	if (!self.mdl_body && world.a_grn_mdl)
+	{
+	  self.mdl_body = world.a_grn_mdl;
+	}
 
 	self.touch = armor_touch;
 	// precache_model ("progs/armor.mdl"); // dumptruck_ds custom models and sounds START
@@ -611,6 +640,11 @@ void() item_armor2 =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
+
+	if (!self.mdl_body && world.a_ylw_mdl)
+	{
+	  self.mdl_body = world.a_ylw_mdl;
+	}
 
 	self.touch = armor_touch;
 	// precache_model ("progs/armor.mdl"); // dumptruck_ds custom models and sounds START
@@ -634,6 +668,11 @@ void() item_armorInv =
 {
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
+
+	if (!self.mdl_body && world.a_red_mdl)
+	{
+	  self.mdl_body = world.a_red_mdl;
+	}
 
 	self.touch = armor_touch;
 	// precache_model ("progs/armor.mdl"); // dumptruck_ds custom models and sounds START
@@ -1139,8 +1178,11 @@ void() item_shells =
 
 	self.touch = ammo_touch;
 
+	
+
 	if (self.spawnflags & WEAPON_BIG2)
 	{
+		if (!self.mdl_body && world.s_lg_mdl) self.mdl_body = world.s_lg_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_shell2.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1159,6 +1201,7 @@ void() item_shells =
 	}
 	else
 	{
+		if (!self.mdl_body && world.s_sm_mdl) self.mdl_body = world.s_sm_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_shell1.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1198,6 +1241,7 @@ void() item_spikes =
 
 	if (self.spawnflags & WEAPON_BIG2)
 	{
+		if (!self.mdl_body && world.n_lg_mdl) self.mdl_body = world.n_lg_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_nails2.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1216,6 +1260,8 @@ void() item_spikes =
 	}
 	else
 	{
+	
+		if (!self.mdl_body && world.n_sm_mdl) self.mdl_body = world.n_sm_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_nails1.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1253,6 +1299,8 @@ void() item_rockets =
 
 	if (self.spawnflags & WEAPON_BIG2)
 	{
+	
+		if (!self.mdl_body && world.r_lg_mdl) self.mdl_body = world.r_lg_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_rock2.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1270,6 +1318,7 @@ void() item_rockets =
 	}
 	else
 	{
+		if (!self.mdl_body && world.r_sm_mdl) self.mdl_body = world.r_sm_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_rock1.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1310,6 +1359,7 @@ void() item_cells =
 
 	if (self.spawnflags & WEAPON_BIG2)
 	{
+		if (!self.mdl_body && world.c_lg_mdl) self.mdl_body = world.c_lg_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_cells2.mdl"); // models courtesy Lunaran -- dumptruck_ds
@@ -1328,6 +1378,7 @@ void() item_cells =
 	}
 	else
 	{
+		if (!self.mdl_body && world.c_sm_mdl) self.mdl_body = world.c_sm_mdl;
 		if (world.style)
 			{
 				precache_body_model ("progs/a_mdls/m_cells2.mdl"); // models courtesy Lunaran -- dumptruck_ds

--- a/misc.qc
+++ b/misc.qc
@@ -1009,6 +1009,7 @@ void() func_episodegate =
 
 	if (self.spawnflags & GATE_REVERSE)
 	{
+		self.spawnflags = self.spawnflags - GATE_REVERSE; // this is to avoid a possible issue with sigil_touch2
 		if (serverflags & self.spawnflags)
 			return;			// Haven't gotten rune yet
 	}
@@ -1019,8 +1020,7 @@ void() func_episodegate =
 	}
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_PUSH;	// so it doesn't get pushed by anything
-	self.solid = SOLID_BSP;if (!(serverflags & self.spawnflags))
-			return;			// can still enter episode
+	self.solid = SOLID_BSP;
 	self.use = func_wall_use;
 	setmodel (self, self.model);
 };

--- a/misc.qc
+++ b/misc.qc
@@ -996,7 +996,10 @@ void() func_illusionary =
 	makestatic (self);
 };
 
-/*QUAKED func_episodegate (0 .5 .8) ? E1 E2 E3 E4
+
+float GATE_REVERSE = 16; // For func_episodegate and func_bossgate appear when player has all runes
+
+/*QUAKED func_episodegate (0 .5 .8) ? E1 E2 E3 E4 REVERSE_FUNCTIONALITY
 This bmodel will appear if the episode has allready been completed, so players can't reenter it.
 */
 void() func_episodegate =
@@ -1004,17 +1007,25 @@ void() func_episodegate =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if (!(serverflags & self.spawnflags))
-		return;			// can still enter episode
-
+	if (self.spawnflags & GATE_REVERSE)
+	{
+		if (serverflags & self.spawnflags)
+			return;			// Haven't gotten rune yet
+	}
+	else
+	{
+		if (!(serverflags & self.spawnflags))
+			return;			// can still enter episode
+	}
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_PUSH;	// so it doesn't get pushed by anything
-	self.solid = SOLID_BSP;
+	self.solid = SOLID_BSP;if (!(serverflags & self.spawnflags))
+			return;			// can still enter episode
 	self.use = func_wall_use;
 	setmodel (self, self.model);
 };
 
-/*QUAKED func_bossgate (0 .5 .8) ?
+/*QUAKED func_bossgate (0 .5 .8) ? X X X X REVERSE_FUNCTIONALITY
 This bmodel appears unless players have all of the episode sigils.
 */
 void() func_bossgate =
@@ -1022,8 +1033,18 @@ void() func_bossgate =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	if ( (serverflags & 15) == 15)
-		return;		// all episodes completed
+	if (self.spawnflags & GATE_REVERSE)
+	{
+		if (!((serverflags & 15) == 15))
+		{
+			return;  // not all complete
+		}
+	}
+	else
+	{
+		if ( (serverflags & 15) == 15 )
+			return;		// all episodes completed
+	}
 	self.angles = '0 0 0';
 	self.movetype = MOVETYPE_PUSH;	// so it doesn't get pushed by anything
 	self.solid = SOLID_BSP;

--- a/misc.qc
+++ b/misc.qc
@@ -1276,9 +1276,11 @@ target = monster that gets mad
 target2 = who target1 will be angry at
 
 spawnflag 1 = mutual hate, both targets get angry at each other instantly
+spawnflag 2 = maintain activator, makes it so the player that triggers the infighting sees centerprints triggered by it
 */
 
 float INFIGHT_MUTUAL = 1;
+float INFIGHT_PLAYER_ACTIVATION = 2;
 
 void(entity t1, entity t2) make_angry_at =
 {
@@ -1298,24 +1300,66 @@ void() misc_infight_use =
 {
 	local entity	t1, t2;
 
-	t1 = find(world, targetname, self.target);
-	t2 = find(world, targetname, self.target2);
+	for (t1 = world; (t1 = find(t1, targetname, self.target)); )
+    {
+      for (t2 = world; (t2 = find(t2, targetname, self.target2)); )
+      {
+  //  t1 = find(world, targetname, self.target);
+  //  t2 = find(world, targetname, self.target2);
 
-	if (!t1)
-	{
-		dprint("[misc_infight] Cannot find target\n");
-		return;
+    	if (!t1)
+    	{
+          dprint("[trigger_infight] Cannot find target, checking targetname2\n");
+          t1 = find(world, targetname2, self.target);
+    	}
+        if (!t1)
+    	{
+   		  dprint("[trigger_infight] Cannot find target, checking targetname3\n");
+   		  t1 = find(world, targetname3, self.target);
+   		}
+    	if (!t1)
+    	{
+          dprint("[trigger_infight] Cannot find target, checking targetname4\n");
+          t1 = find(world, targetname4, self.target);
+        }
+    	if (!t1)
+    	{
+          dprint("[trigger_infight] Cannot find target, exhausted all targetnames\n");
+          return;
+    	}
+    	if (!t2)
+    	{
+          dprint("[trigger_infight] Cannot find target2 checking targetname2\n");
+          t2 = find(world, targetname2, self.target2);
+    	}
+    	if (!t2)
+    	{
+          dprint("[trigger_infight] Cannot find target2 checking targetname3\n");
+          t2 = find(world, targetname3, self.target2);
+    	}
+    	if (!t2)
+    	{
+          dprint("[trigger_infight] Cannot find target2 checking targetname4\n");
+          t2 = find(world, targetname4, self.target2);
+    	}
+    	if (!t2)
+    	{
+          dprint("[trigger_infight] Cannot find target2, exhausted all targetnames\n");
+          return;
+    	}
+
+		make_angry_at(t1, t2);
+
+		if (self.spawnflags & INFIGHT_PLAYER_ACTIVATION)
+      	{
+          t1.infight_activator = activator;
+          t2.infight_activator = activator;
+      	}
+
+		if (self.spawnflags & INFIGHT_MUTUAL)
+		  make_angry_at(t2, t1);
+	  }
 	}
-	if (!t2)
-	{
-		dprint("[misc_infight] Cannot find target2\n");
-		return;
-	}
-
-	make_angry_at(t1, t2);
-
-	if (self.spawnflags & INFIGHT_MUTUAL)
-		make_angry_at(t2, t1);
 };
 
 void() misc_infight =

--- a/mobot.qc
+++ b/mobot.qc
@@ -37,7 +37,7 @@ void() create_mobot =
 // ------------------------------------------------
 {
 
-local entity bot, spawn_spot, oself;
+local entity bot, spawn_spot;
 
 // start entity and place it in world
 	bot = spawn();
@@ -419,10 +419,7 @@ if (self.style == 12) // spawn a Shalrath
 	}
 	else
 	{
-		oself = self;
-		self = bot;
-		walkmonster_start();
-		self = oself;
+		bot.think = walkmonster_start_go;
 	}
 	if (!(self.spawnflags & MOBOT_DONT_ADD_KILL_COUNT))
 	{
@@ -453,7 +450,6 @@ void() think_mobot =
 
 		if (self.count < 0)
 		{
-
 			return;
 		}
 		if (self.count!=0)

--- a/mobot.qc
+++ b/mobot.qc
@@ -10,6 +10,8 @@
 float MOBOT_SPAWNER_RESET = 1;
 float MOBOT_DONT_SPAWN_ANGRY = 2;
 float MOBOT_DONT_ADD_KILL_COUNT = 4;
+float MOBOT_SILENT_SPAWN = 32;
+
 /*
 ============
 MobotSpawnPoint
@@ -45,7 +47,7 @@ local entity bot, spawn_spot, oself;
 	bot.angles = spawn_spot.angles;
 	bot.fixangle = TRUE;
 	bot.proj_speed_mod = 1;
-	if (!(self.spawnflags & 32)) 			// SILENT
+	if (!(self.spawnflags & MOBOT_SILENT_SPAWN)) 			// SILENT
 	spawn_tfog (bot.origin);
 	spawn_tdeath (bot.origin, bot);
 
@@ -421,7 +423,6 @@ if (self.style == 12) // spawn a Shalrath
 		self = bot;
 		walkmonster_start();
 		self = oself;
-		/* bot.think = bot.th_stand; */
 	}
 	if (!(self.spawnflags & MOBOT_DONT_ADD_KILL_COUNT))
 	{
@@ -471,7 +472,8 @@ void() think_mobot =
 				create_mobot();
 		}
 		else {
-			if (self.spawnflags & MOBOT_SPAWNER_RESET){
+			if (self.spawnflags & MOBOT_SPAWNER_RESET)
+			{
 			  self.count = self.cnt;
 				self.think = SUB_Null;
 			}

--- a/mobot.qc
+++ b/mobot.qc
@@ -6,6 +6,10 @@
 // ===================================================================
 // Big thanks to ryanscissorhands for helping fix telefragging issues!
 // ===================================================================
+
+float MOBOT_SPAWNER_RESET = 1;
+float MOBOT_DONT_SPAWN_ANGRY = 2;
+float MOBOT_DONT_ADD_KILL_COUNT = 4;
 /*
 ============
 MobotSpawnPoint
@@ -31,7 +35,7 @@ void() create_mobot =
 // ------------------------------------------------
 {
 
-local entity bot, spawn_spot;
+local entity bot, spawn_spot, oself;
 
 // start entity and place it in world
 	bot = spawn();
@@ -371,7 +375,6 @@ if (self.style == 11) // spawn a Zombie
 	bot.view_ofs = '0 0 2';
 	// bot.view_ofs = '0 0 22';
 	}
-
 if (self.style == 12) // spawn a Shalrath
 	{
 		// set size and shape
@@ -405,17 +408,30 @@ if (self.style == 12) // spawn a Shalrath
 // begin his thinking
 	bot.nextthink = time + 0.2; // this seems better with monster_use -- dumptruck_ds
 	// bot.nextthink = time + 0.1 + random();
-	if (bot.classname != "monster_zombie") // required to avoid animation issues -- dumptruck_ds
-	bot.think = monster_use;
+	if (!(self.spawnflags & MOBOT_DONT_SPAWN_ANGRY))
+	{
+		if (bot.classname != "monster_zombie") // required to avoid animation issues -- dumptruck_ds
+			bot.think = monster_use;
+		else
+			bot.think = bot.th_walk;
+	}
 	else
-	bot.think = bot.th_walk;
-	monster_update_total (1); // repacement function from iw -- dumptruck_ds
-
+	{
+		oself = self;
+		self = bot;
+		walkmonster_start();
+		self = oself;
+		/* bot.think = bot.th_stand; */
+	}
+	if (!(self.spawnflags & MOBOT_DONT_ADD_KILL_COUNT))
+	{
+		monster_update_total (1); // repacement function from iw -- dumptruck_ds
+	}
 };
 
 void() think_mobot =
 	{
-
+		dprint("mobot thinking\n");
 		local entity  nearby; // telefrag check thanks to ryanscissorhands for this code! -- dumptruck_ds
 
 		nearby = findradius(self.origin, 128); // findradius (vector origin, float radius in Quake units)
@@ -435,7 +451,10 @@ void() think_mobot =
 		self.count = self.count - 1;
 
 		if (self.count < 0)
-		return;
+		{
+
+			return;
+		}
 		if (self.count!=0)
 		{
 			if !(self.wait)
@@ -451,13 +470,19 @@ void() think_mobot =
 			else
 				create_mobot();
 		}
+		else {
+			if (self.spawnflags & MOBOT_SPAWNER_RESET){
+			  self.count = self.cnt;
+				self.think = SUB_Null;
+			}
+		}
 
 		self.think = think_mobot; // qthink I didn't realize I could do this! -- dumptruck_ds
 	};
 
-/*QUAKED func_monster_spawner (.75 0 .75) (-8 -8 -8) (8 8 8) X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
+/*QUAKED func_monster_spawner (.75 0 .75) (-8 -8 -8) (8 8 8) REUSABLE X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 Spawns monsters to targeted info_monster_spawnpoint
-
+bot
 Choose Style
 • 1 (Dog (Default)
 • 2 (Grunt)
@@ -498,6 +523,7 @@ void() func_monster_spawner =
 	if (!self.count)
 		self.count = 5;
 	self.count = self.count + 1; // fixes count display
+	self.cnt = self.count; // hold original count
 
 	self.use = think_mobot;
 };

--- a/monsters.qc
+++ b/monsters.qc
@@ -206,7 +206,14 @@ void() monster_death_use =
 	if (!self.target)
 		return;
 
-	activator = self.enemy;
+	if(self.infight_activator)
+	{
+		activator = self.infight_activator;
+	} 
+	else
+	{
+		activator = self.enemy;
+	}
 	SUB_UseTargets ();
 };
 


### PR DESCRIPTION
3 features I did a long time ago and forgot to add, and one new one I thought up the other day and whipped up fast.

1) Additional behaviors for Mobots. These are Resetting (so once it has spawned the `count` monsters, it sets back up to be retriggered again), Don't Spawn Angry, and Don't Add Kill Count. 
2) Improvement to `misc_infight` that allows the player to be the activator of anything the fighting monsters do. Useful for cutscenes.
3) A spawnflag to reverse how episode gates and boss gates work - so episode gates disappear and boss gates appear when the appropriate runes are obtained.
4) Default model settings. This allows you to on a map-by-map basis select "default" health / ammo / armor mdls. 