### PR TITLE
Added custom options for trigger_count entity.

### DIFF
--- a/defs.qc
+++ b/defs.qc
@@ -566,6 +566,12 @@ float	AS_TURRET		= 5;
 //
 .float		count;			// for counting triggers
 
+// For trigger_count
+.string		message_more;		// Use for "There are more to go..."
+.string		message_complete;	// Use for "Sequence completed!"
+.string		message_count;		// Use for "Only % more to go..."
+.string		message_one;		// Use for "Only 1 more to go..."
+.float		count_more;			// If more than this value remains, 'message_more' is used. -1 to never.
 
 //
 // plats / doors / buttons

--- a/fgd_def/pd_300.def
+++ b/fgd_def/pd_300.def
@@ -788,9 +788,13 @@ set "message" to text string
 
 Acts as an intermediary for an action that takes multiple inputs.
 
-If nomessage is not set, t will print "1 more.. " etc when triggered and "sequence complete" when finished.
-
-After the counter has been triggered "count" times (default 2), it will fire all of it's targets and remove itself.
+Personalize messages:
+- message_complete: Message to show when the sequence is complete. (default: "Sequence completed!")
+- message_more: Message to show when there are more to go. Using % within the message will show the remaining count. (default: "There are more to go...")
+- message_count: Message to specify the remaining count. Using % within the message will show the remaining count. (default: "Only % more to go...")
+- message_one (optional): Custom message when only one remains. Defaults to 'message_count' behavior.
+- count: After the counter has been triggered "count" times it will fire all of it's targets and remove itself. (default: 2)
+- count_more: If more than this quantity remains, 'message_more' is used. -1 to ignore 'message_more' logic. (default: 3)
 */
 /*QUAKED info_teleport_changedest (0 0.5 0) (-8 -8 -8) (8 8 8) X X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
 Allows a mapper to change the target of a teleport_trigger. Useful in maps where

--- a/fgd_def/pd_300.fgd
+++ b/fgd_def/pd_300.fgd
@@ -2415,12 +2415,21 @@ Make sure and add a weapon_shotgun to your map!"
 	height(integer) : "Jump Height" : 200
 	spawnflags(flags) = [ 8: "Start Off (toggles)" : 0 ] //dumptruck_ds
 ]
-@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
+@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter
+
+message_complete: Message to show when the sequence is complete.
+message_more: Message to show when there are more to go. Using % within the message will show the remaining count
+message_count: Message to specify the remaining count. Using % within the message will show the remaining count.
+message_one (optional): Custom message when only one remains. Defaults to 'message_count' behavior.
+count_more: If more than this quantity remains, 'message_more' is used. -1 to ignore 'message_more' logic."
 [
 	spawnflags(flags) = [ 1: "No Message" : 0 ]
 	count(integer) : "Count before trigger" : 2
-	delay (integer) : "Delay"
-	message(string) : "Message"
+	message_complete(string) : "Message on sequence completed" : "Sequence completed!"
+	message_more(string) : "Message to show when there are more to go. Use % for the remaining count." : "There are more to go..."
+	message_count(string) : "Message to specify the remaining count. Use % for the remaining count." : "Only % more to go..."
+	message_one(string) : "Custom message when there's only one more to go (optional)"
+	count_more(integer) : "If more than this quantity remains, 'message_more' will be shown. Use -1 to always show the count." : 3
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [

--- a/fgd_def/pd_300_JACK.fgd
+++ b/fgd_def/pd_300_JACK.fgd
@@ -2171,12 +2171,21 @@ spawnflags(Flags) =
 	height(integer) : "Jump Height" : 200
 	spawnflags(flags) = [ 8: "Start Off (toggles)" : 0 ] //dumptruck_ds
 ]
-@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter"
+@PointClass base(Appearflags, Target, Targetname) = trigger_counter : "Trigger: Counter
+
+message_complete: Message to show when the sequence is complete.
+message_more: Message to show when there are more to go. Using % within the message will show the remaining count
+message_count: Message to specify the remaining count. Using % within the message will show the remaining count.
+message_one (optional): Custom message when only one remains. Defaults to 'message_count' behavior.
+count_more: If more than this quantity remains, 'message_more' is used. -1 to ignore 'message_more' logic."
 [
 	spawnflags(flags) = [ 1: "No Message" : 0 ]
 	count(integer) : "Count before trigger" : 2
-	delay (integer) : "Delay"
-	message(string) : "Message"
+	message_complete(string) : "Message on sequence completed" : "Sequence completed!"
+	message_more(string) : "Message to show when there are more to go. Use % for the remaining count." : "There are more to go..."
+	message_count(string) : "Message to specify the remaining count. Use % for the remaining count." : "Only % more to go..."
+	message_one(string) : "Custom message when there's only one more to go (optional)"
+	count_more(integer) : "If more than this quantity remains, 'message_more' will be shown. Use -1 to always show the count." : 3
 ]
 @SolidClass base(Angle, Appearflags, Targetname, TriggerWait) = trigger_push : "Trigger: Push"
 [

--- a/progs.src
+++ b/progs.src
@@ -2,6 +2,7 @@
 #pragma autoproto
 
 defs.qc //added fields, see comments for details
+string_lib.qc // String handling functions
 newflags.qc //new spawnflags for all entities
 math.qc // Code by Joshua Skelton
 utility.qc

--- a/string_lib.qc
+++ b/string_lib.qc
@@ -1,0 +1,69 @@
+
+// Extracted from: https://github.com/SimsOCallaghan/ArcaneDimensions/blob/master/dpextensions.qc
+//FTE_STRINGS
+//idea: many
+//darkplaces implementation: KrimZon
+//builtin definitions:
+float(string str, string sub, float startpos) strstrofs = #221; // returns the offset into a string of the matching text, or -1 if not found, case sensitive
+float(string str, float ofs) str2chr = #222; // returns the character at the specified offset as an integer, or 0 if an invalid index, or byte value - 256 if the engine supports UTF8 and the byte is part of an extended character
+string(float c, ...) chr2str = #223; // returns a string representing the character given, if the engine supports UTF8 this may be a multi-byte sequence (length may be more than 1) for characters over 127.
+string(float ccase, float calpha, float cnum, string s, ...) strconv = #224; // reformat a string with special color characters in the font, DO NOT USE THIS ON UTF8 ENGINES (if you are lucky they will emit ^4 and such color codes instead), the parameter values are 0=same/1=lower/2=upper for ccase, 0=same/1=white/2=red/5=alternate/6=alternate-alternate for redalpha, 0=same/1=white/2=red/3=redspecial/4=whitespecial/5=alternate/6=alternate-alternate for rednum.
+string(float chars, string s, ...) strpad = #225; // pad string with spaces to a specified length, < 0 = left padding, > 0 = right padding
+string(string info, string key, string value, ...) infoadd = #226; // sets or adds a key/value pair to an infostring - note: forbidden characters are \ and "
+string(string info, string key) infoget = #227; // gets a key/value pair in an infostring, returns value or null if not found
+float(string s1, string s2, float len) strncmp = #228; // compare two strings up to the specified number of characters, if their length differs and is within the specified limit the result will be negative, otherwise it is the difference in value of their first non-matching character.
+float(string s1, string s2) strcasecmp = #229; // compare two strings with case-insensitive matching, characters a-z are considered equivalent to the matching A-Z character, no other differences, and this does not consider special characters equal even if they look similar
+float(string s1, string s2, float len) strncasecmp = #230; // same as strcasecmp but with a length limit, see strncmp
+//string(string s, float start, float length) substring = #116; // see note below
+//description:
+//various string manipulation functions
+//note: substring also exists in FRIK_FILE but this extension adds negative start and length as valid cases (see note above), substring is consistent with the php 5.2.0 substr function (not 5.2.3 behavior)
+//substring returns a section of a string as a tempstring, if given negative
+// start the start is measured back from the end of the string, if given a
+// negative length the length is the offset back from the end of the string to
+// stop at, rather than being relative to start, if start is negative and
+// larger than length it is treated as 0.
+// examples of substring:
+// substring("blah", -3, 3) returns "lah"
+// substring("blah", 3, 3) returns "h"
+// substring("blah", -10, 3) returns "bla"
+// substring("blah", -10, -3) returns "b"
+
+// Extracted from: https://github.com/SimsOCallaghan/ArcaneDimensions/blob/master/dpextensions.qc
+//DP_QC_STRREPLACE
+//idea: Sajt
+//darkplaces implementation: Sajt
+//builtin definitions:
+string(string search, string replace, string subject) strreplace = #484;
+string(string search, string replace, string subject) strireplace = #485;
+//description:
+//strreplace replaces all occurrences of 'search' with 'replace' in the string 'subject', and returns the result as a tempstring.
+//strireplace does the same but uses case-insensitive matching of the 'search' term
+
+// Extracted from: https://github.com/SimsOCallaghan/ArcaneDimensions/blob/master/dpextensions.qc
+//FRIK_FILE
+//idea: FrikaC
+//darkplaces implementation: LordHavoc
+//builtin definitions:
+float(string s) stof = #81; // get numerical value from a string
+float(string s) strlen = #114; // returns how many characters are in a string
+string(string s1, string s2, ...) strcat = #115; // concatenates two or more strings (for example "abc", "def" would return "abcdef") and returns as a tempstring
+vector(string s) stov = #117; // returns vector value from a string
+
+/*
+================
+template_string
+template_string_token
+by: rijuma
+
+Replaces a variable in a string. template_string_token() variant is to specify the token.
+
+subject (string): The string template.
+value (string): The value to be inserted in the string template.
+token (string): The substring to be searched and replaced with the value. In template_string is ommited and defaulted to TEMPLATE_TOKEN.
+================
+*/
+string	TEMPLATE_TOKEN = "%";
+
+string(string subject, string value) template_string = { return template_string_token(subject, value, TEMPLATE_TOKEN); }
+string(string subject, string value, string token) template_string_token = { return strreplace(token, value, subject); }

--- a/triggers.qc
+++ b/triggers.qc
@@ -261,47 +261,59 @@ void() trigger_secret =
 	trigger_multiple ();
 };
 
-//=============================================================================
+/*
+==============================================================================
 
+Added custom message options for trigger_counter.
+-- rijuma
+
+==============================================================================
+*/
 
 void() counter_use =
 {
 	if (self.estate != STATE_ACTIVE) return;
 
-	self.count = self.count - 1;
-	if (self.count < 0)
-		return;
+	// Is self.count is 0 or less, this was already done. Ignore.
+	if (self.count <= 0) return;
 
-	if (self.count != 0)
-	{
-		if (activator.classname == "player"
-		&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		{
-			if (self.count >= 4)
-				centerprint (activator, "There are more to go...");
-			else if (self.count == 3)
-				centerprint (activator, "Only 3 more to go...");
-			else if (self.count == 2)
-				centerprint (activator, "Only 2 more to go...");
-			else
-				centerprint (activator, "Only 1 more to go...");
-		}
-		return;
+	
+	
+	self.count = self.count - 1;
+	
+	// Check conditions for showing message
+	local float showMessage = (activator.classname == "player" && (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0);
+	
+	// If the count reaches 0, we trigger the event.
+	if (self.count == 0) {
+		if (showMessage)
+			centerprint (activator, self.message_complete);
+
+		self.enemy = activator;
+		return multi_trigger ();
 	}
 
-	if (activator.classname == "player"
-	&& (self.spawnflags & SPAWNFLAG_NOMESSAGE) == 0)
-		centerprint(activator, "Sequence completed!");
-	self.enemy = activator;
-	multi_trigger ();
+	// Otherwise, more activations remain, so let's handle that.
+
+	// If there's no message, then nothing to do here.
+	if (!showMessage) return;
+
+	// First we check if we want to tell exactly how many attempts we have left or not.
+	// If the remaining count is greater than count_more, we do use message_more.
+	// Use count_more = -1 to Never use message_more (Always use message_count).
+	if (self.count_more != -1 && self.count > self.count_more)
+	 return centerprint (activator, template_string(self.message_more, ftos(self.count)));
+
+	// If only one remains, we check if we have a custom message for this case, otherwise we use the template.
+	if (self.count == 1 && self.message_one)
+		return centerprint (activator, self.message_one);
+	
+	// We use the message_count string.
+	centerprint (activator, template_string(self.message_count, ftos(self.count)));
 };
 
 /*QUAKED trigger_counter (.5 .5 .5) ? nomessage X X X X X X X NOT_ON_EASY NOT_ON_NORMAL NOT_ON_HARD_OR_NIGHTMARE NOT_IN_DEATHMATCH NOT_IN_COOP NOT_IN_SINGLEPLAYER X NOT_ON_HARD_ONLY NOT_ON_NIGHTMARE_ONLY
-
 Acts as an intermediary for an action that takes multiple inputs.
-
-If nomessage is not set, t will print "1 more.. " etc when triggered and "sequence complete" when finished.
-
 After the counter has been triggered "count" times (default 2), it will fire all of it's targets and remove itself.
 */
 void() trigger_counter =
@@ -309,11 +321,34 @@ void() trigger_counter =
 	if (SUB_Inhibit ())  // new spawnflags for all entities -- iw
 		return;
 
-	self.wait = -1;
+	self.use = counter_use;
+
+	self.wait = -1; // This disables wait for some reason, I've removed it from the .fgd/.def file. Maybe a TODO check for this functionality?
+
+	// Default values
 	if (!self.count)
 		self.count = 2;
 
-	self.use = counter_use;
+	if (!self.message_complete) {
+		// Retro compatible with the message parameter.
+		if (self.message) 
+			self.message_complete = self.message;
+		else
+			self.message_complete = "Sequence completed!";
+	}
+
+	// Clear deprecated message parameter.
+	self.message = "";
+
+	if (!self.message_count)
+		self.message_count = strcat ("Only ", TEMPLATE_TOKEN, " more to go...");
+
+	if (!self.message_more)
+		self.message_more = "There are more to go...";
+
+	if (!self.count_more)
+		self.count_more = 3;
+
 };
 
 /*


### PR DESCRIPTION
## New stuff added

### Entity: `trigger_counter`

#### Params added
- `message_complete`: Message to show when the sequence is complete. _(default: "Sequence completed!")_
- `message_more`: Message to show when there are more to go. Using **%** within the message will show the remaining count. _(default: "There are more to go...")_
- `message_count`: Message to specify the remaining count. Using **%** within the message will show the remaining count. _(default: "Only % more to go...")_
- `message_one` _(optional)_: Custom message when only one remains. Defaults to `message_count` behavior.
- `count_more`: If more than this quantity remains, `message_more` is used. **-1** to ignore `message_more` logic. _(default: 3)_

#### Params removed (from fgd y def) files
- `wait`: If you check progs_dump's current code, it basically sets the wait to **-1** disabling its behavior. No use being shown in the editor.
- `message`: Since it now has several message parameters, I use it as an alias for `message_complete` for backward compatibility, but I removed it from the editor to discourage its use since it's clearer this way.

## Extra notes

I've added a new `strings_lib.qc` file as a library with string handling functions. I extracted some code from [SimsOCallaghan's ArcaneDimensions repo](https://github.com/SimsOCallaghan/ArcaneDimensions/blob/master/dpextensions.qc) which makes these Dark Places' built-in utils available.
In the same file below, I added a couple of one-liner functions, more like a "concept" to be used for string interpolation. Really simple though.

## Test map
[trigger_count_test.zip](https://github.com/dumptruckDS/progs_dump_qc/files/10871649/trigger_count_test.zip)

## Screenshots
![image](https://user-images.githubusercontent.com/12736783/222437606-95ef489a-a5dd-4327-bdb8-d6d1c6de0a82.png)
